### PR TITLE
Adding PrintOverlaps to ViewGdml.C

### DIFF
--- a/macros/ViewGdml.C
+++ b/macros/ViewGdml.C
@@ -5,6 +5,8 @@ void ViewGdml(string filename, float transparency = 50)
     // check for overlaps
     TGeoNode *node = gGeoManager->GetTopNode();
     node->CheckOverlaps(0.0001);
+    // print overlaps
+    gGeoManager->PrintOverlaps();
 
     for (auto i = 0; i < gGeoManager->GetListOfVolumes()->GetEntries(); i++)
     {


### PR DESCRIPTION
Just add PrintOverlaps method to the macro ViewGdml.C

When there is an overlap in the geometry, it prints information about the volumes that are overlapping and the overlap distance. For example:
`= Overlap ov00000: Chamber/gas overlapping Chamber/cathodeCopperDiskPattern ovlp=0.05`