### PR TITLE
Adding radiopure electronics 

### DIFF
--- a/gdml/BabyIAXO/ChamberAndPipe.gdml
+++ b/gdml/BabyIAXO/ChamberAndPipe.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="worldBox" x="1450.0" y="1600.0" z="1450.0"/>
     </solids>
     <structure>
@@ -3608,6 +3614,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="world">
             <physvol name="Chamber">
                 <volumeref ref="Chamber"/>
@@ -3615,6 +3637,10 @@
             <physvol name="DetectorPipe">
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
+            </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
             </physvol>
             <materialref ref="G4_AIR"/>
             <solidref ref="worldBox"/>

--- a/gdml/BabyIAXO/ChamberAndPipe.gdml
+++ b/gdml/BabyIAXO/ChamberAndPipe.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="worldBox" x="1450.0" y="1600.0" z="1450.0"/>
     </solids>
     <structure>
@@ -3622,12 +3624,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="world">
@@ -3640,7 +3676,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <materialref ref="G4_AIR"/>
             <solidref ref="worldBox"/>

--- a/gdml/BabyIAXO/CompleteVeto1Layers.gdml
+++ b/gdml/BabyIAXO/CompleteVeto1Layers.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3663,6 +3669,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3697,249 +3719,249 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-800.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-800.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-800.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266210">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266211">
+            <physvol name="captureLayerVolume-800.0mm-73266211">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266211.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266212.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+            <physvol name="assembly-6.veto1">
                 <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop1.position" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto4">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-9">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto4">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-10">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom1.position" y="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-10">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df66">
+        <assembly name="assembly-11">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df67">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df67">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df68">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df68">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-11">
-            <physvol name="assembly-11.veto1">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto2">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto3">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto4">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-12">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-12.veto1">
                 <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto2">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto3">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto4">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-13">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-13">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df69">
+        <assembly name="assembly-14">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6a">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6a">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6b">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6c">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6d">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6d">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6d.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6d.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-14">
-            <physvol name="assembly-14.veto1">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto2">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto3">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto4">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6e.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-15">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-15.veto1">
                 <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto2">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto3">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto4">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-16">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-16">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6c">
+        <assembly name="assembly-17">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6d">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6d">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6e">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6f">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df70">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df71">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df70.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-17">
-            <physvol name="assembly-17.veto1">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto2">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto3">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto4">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df71.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-18">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-18.veto1">
                 <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto2">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto3">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto4">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-19">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack1.position" y="80.0" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-19">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
+        <assembly name="assembly-20">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df85">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df86">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df71">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df87">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df89">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df89.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-300.0mm">
@@ -3958,75 +3980,75 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-300.0mm"/>
         </volume>
-        <assembly name="assembly-20">
-            <physvol name="scintillatorVolume-300.0mm-f1a5df85">
+        <assembly name="assembly-21">
+            <physvol name="scintillatorVolume-300.0mm-f1a5df86">
                 <volumeref ref="scintillatorVolume-300.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df86">
+            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df87">
                 <volumeref ref="scintillatorWrappingSolid-300.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-300.0mm-f1a5df87">
-                <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-300.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df89">
+            <physvol name="captureLayerVolume-300.0mm-f1a5df89">
+                <volumeref ref="captureLayerVolume-300.0mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df8a">
                 <volumeref ref="scintillatorLightGuideVolume-300.0mm"/>
-                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df89.position" z="-215.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df8a.position" z="-215.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
+        <assembly name="assembly-22">
             <physvol name="veto0">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto0.position" x="-207.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmall1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmall1.position" z="-250.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmallRotated1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmallRotated1.position" z="250.0" unit="mm"/>
                 <rotation name="vetoSmallRotated1.rotation" x="180.0" unit="deg"/>
             </physvol>
             <physvol name="veto2">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto2.position" x="207.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-22">
+        <assembly name="assembly-23">
             <physvol name="vetoLayerFront1">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-9"/>
+                <volumeref ref="assembly-10"/>
                 <position name="vetoSystemBottom.position" y="-357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-12"/>
+                <volumeref ref="assembly-13"/>
                 <position name="vetoSystemRight.position" x="-467.0" z="-10.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-15"/>
+                <volumeref ref="assembly-16"/>
                 <position name="vetoSystemLeft.position" x="467.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-18"/>
+                <volumeref ref="assembly-19"/>
                 <position name="vetoSystemBack.position" y="80.0" z="-422.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoSystemFront.position" z="461.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4038,11 +4060,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
             </physvol>
             <materialref ref="G4_AIR"/>
             <solidref ref="worldBox"/>

--- a/gdml/BabyIAXO/CompleteVeto1Layers.gdml
+++ b/gdml/BabyIAXO/CompleteVeto1Layers.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3677,12 +3679,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4062,7 +4098,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/BabyIAXO/CompleteVeto2Layers.gdml
+++ b/gdml/BabyIAXO/CompleteVeto2Layers.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3663,6 +3669,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3697,274 +3719,274 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-800.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-800.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-800.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266210">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266211">
+            <physvol name="captureLayerVolume-800.0mm-73266211">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266211.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266212.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+            <physvol name="assembly-6.veto1">
                 <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop1.position" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop2">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop2.position" y="74.0" unit="mm"/>
                 <rotation name="vetoLayerTop2.rotation" y="180.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto4">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-9">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto4">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-10">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom1.position" y="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom2">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom2.position" y="-54.0" unit="mm"/>
                 <rotation name="vetoLayerBottom2.rotation" y="540.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-10">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df66">
+        <assembly name="assembly-11">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df67">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df67">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df68">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df68">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-11">
-            <physvol name="assembly-11.veto1">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto2">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto3">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto4">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-12">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-12.veto1">
                 <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto2">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto3">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto4">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-13">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight2">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight2.position" x="-74.0" unit="mm"/>
                 <rotation name="vetoLayerRight2.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-13">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df69">
+        <assembly name="assembly-14">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6a">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6a">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6b">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6c">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6d">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6d">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6d.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6d.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-14">
-            <physvol name="assembly-14.veto1">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto2">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto3">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto4">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6e.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-15">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-15.veto1">
                 <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto2">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto3">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto4">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-16">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft2">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft2.position" x="74.0" unit="mm"/>
                 <rotation name="vetoLayerLeft2.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-16">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6c">
+        <assembly name="assembly-17">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6d">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6d">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6e">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6f">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df70">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df71">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df70.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-17">
-            <physvol name="assembly-17.veto1">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto2">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto3">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto4">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df71.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-18">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-18.veto1">
                 <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto2">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto3">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto4">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-19">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack1.position" y="80.0" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack2">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack2.position" y="80.0" z="-74.0" unit="mm"/>
                 <rotation name="vetoLayerBack2.rotation" x="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-19">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
+        <assembly name="assembly-20">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df85">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df86">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df71">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df87">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df89">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df89.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-300.0mm">
@@ -3983,80 +4005,80 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-300.0mm"/>
         </volume>
-        <assembly name="assembly-20">
-            <physvol name="scintillatorVolume-300.0mm-f1a5df85">
+        <assembly name="assembly-21">
+            <physvol name="scintillatorVolume-300.0mm-f1a5df86">
                 <volumeref ref="scintillatorVolume-300.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df86">
+            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df87">
                 <volumeref ref="scintillatorWrappingSolid-300.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-300.0mm-f1a5df87">
-                <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-300.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df89">
+            <physvol name="captureLayerVolume-300.0mm-f1a5df89">
+                <volumeref ref="captureLayerVolume-300.0mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df8a">
                 <volumeref ref="scintillatorLightGuideVolume-300.0mm"/>
-                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df89.position" z="-215.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df8a.position" z="-215.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
+        <assembly name="assembly-22">
             <physvol name="veto0">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto0.position" x="-207.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmall1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmall1.position" z="-250.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmallRotated1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmallRotated1.position" z="250.0" unit="mm"/>
                 <rotation name="vetoSmallRotated1.rotation" x="180.0" unit="deg"/>
             </physvol>
             <physvol name="veto2">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto2.position" x="207.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-22">
+        <assembly name="assembly-23">
             <physvol name="vetoLayerFront1">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront2">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront2.position" z="74.0" unit="mm"/>
                 <rotation name="vetoLayerFront2.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-9"/>
+                <volumeref ref="assembly-10"/>
                 <position name="vetoSystemBottom.position" y="-357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-12"/>
+                <volumeref ref="assembly-13"/>
                 <position name="vetoSystemRight.position" x="-467.0" z="-10.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-15"/>
+                <volumeref ref="assembly-16"/>
                 <position name="vetoSystemLeft.position" x="467.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-18"/>
+                <volumeref ref="assembly-19"/>
                 <position name="vetoSystemBack.position" y="80.0" z="-422.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoSystemFront.position" z="461.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4068,11 +4090,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
             </physvol>
             <materialref ref="G4_AIR"/>
             <solidref ref="worldBox"/>

--- a/gdml/BabyIAXO/CompleteVeto2Layers.gdml
+++ b/gdml/BabyIAXO/CompleteVeto2Layers.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3677,12 +3679,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4092,7 +4128,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/BabyIAXO/CompleteVeto3Layers.gdml
+++ b/gdml/BabyIAXO/CompleteVeto3Layers.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3663,6 +3669,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3697,299 +3719,299 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-800.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-800.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-800.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266210">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266211">
+            <physvol name="captureLayerVolume-800.0mm-73266211">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266211.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266212.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+            <physvol name="assembly-6.veto1">
                 <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop1.position" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop2">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop2.position" y="74.0" unit="mm"/>
                 <rotation name="vetoLayerTop2.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop3">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop3.position" y="148.0" unit="mm"/>
                 <rotation name="vetoLayerTop3.rotation" y="180.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto4">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-9">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto4">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-10">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom1.position" y="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom2">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom2.position" y="-54.0" unit="mm"/>
                 <rotation name="vetoLayerBottom2.rotation" y="540.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom3">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom3.position" y="-108.0" unit="mm"/>
                 <rotation name="vetoLayerBottom3.rotation" y="720.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-10">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df66">
+        <assembly name="assembly-11">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df67">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df67">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df68">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df68">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-11">
-            <physvol name="assembly-11.veto1">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto2">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto3">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto4">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-12">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-12.veto1">
                 <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto2">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto3">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto4">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-13">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight2">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight2.position" x="-74.0" unit="mm"/>
                 <rotation name="vetoLayerRight2.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight3">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight3.position" x="-148.0" unit="mm"/>
                 <rotation name="vetoLayerRight3.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-13">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df69">
+        <assembly name="assembly-14">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6a">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6a">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6b">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6c">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6d">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6d">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6d.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6d.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-14">
-            <physvol name="assembly-14.veto1">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto2">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto3">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto4">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6e.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-15">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-15.veto1">
                 <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto2">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto3">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto4">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-16">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft2">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft2.position" x="74.0" unit="mm"/>
                 <rotation name="vetoLayerLeft2.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft3">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft3.position" x="148.0" unit="mm"/>
                 <rotation name="vetoLayerLeft3.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-16">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6c">
+        <assembly name="assembly-17">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6d">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6d">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6e">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6f">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df70">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df71">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df70.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-17">
-            <physvol name="assembly-17.veto1">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto2">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto3">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto4">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df71.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-18">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-18.veto1">
                 <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto2">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto3">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto4">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-19">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack1.position" y="80.0" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack2">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack2.position" y="80.0" z="-74.0" unit="mm"/>
                 <rotation name="vetoLayerBack2.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack3">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack3.position" y="80.0" z="-148.0" unit="mm"/>
                 <rotation name="vetoLayerBack3.rotation" x="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-19">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
+        <assembly name="assembly-20">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df85">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df86">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df71">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df87">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df89">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df89.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-300.0mm">
@@ -4008,85 +4030,85 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-300.0mm"/>
         </volume>
-        <assembly name="assembly-20">
-            <physvol name="scintillatorVolume-300.0mm-f1a5df85">
+        <assembly name="assembly-21">
+            <physvol name="scintillatorVolume-300.0mm-f1a5df86">
                 <volumeref ref="scintillatorVolume-300.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df86">
+            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df87">
                 <volumeref ref="scintillatorWrappingSolid-300.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-300.0mm-f1a5df87">
-                <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-300.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df89">
+            <physvol name="captureLayerVolume-300.0mm-f1a5df89">
+                <volumeref ref="captureLayerVolume-300.0mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df8a">
                 <volumeref ref="scintillatorLightGuideVolume-300.0mm"/>
-                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df89.position" z="-215.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df8a.position" z="-215.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
+        <assembly name="assembly-22">
             <physvol name="veto0">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto0.position" x="-207.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmall1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmall1.position" z="-250.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmallRotated1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmallRotated1.position" z="250.0" unit="mm"/>
                 <rotation name="vetoSmallRotated1.rotation" x="180.0" unit="deg"/>
             </physvol>
             <physvol name="veto2">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto2.position" x="207.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-22">
+        <assembly name="assembly-23">
             <physvol name="vetoLayerFront1">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront2">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront2.position" z="74.0" unit="mm"/>
                 <rotation name="vetoLayerFront2.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront3">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront3.position" z="148.0" unit="mm"/>
                 <rotation name="vetoLayerFront3.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-9"/>
+                <volumeref ref="assembly-10"/>
                 <position name="vetoSystemBottom.position" y="-357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-12"/>
+                <volumeref ref="assembly-13"/>
                 <position name="vetoSystemRight.position" x="-467.0" z="-10.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-15"/>
+                <volumeref ref="assembly-16"/>
                 <position name="vetoSystemLeft.position" x="467.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-18"/>
+                <volumeref ref="assembly-19"/>
                 <position name="vetoSystemBack.position" y="80.0" z="-422.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoSystemFront.position" z="461.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4098,11 +4120,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
             </physvol>
             <materialref ref="G4_AIR"/>
             <solidref ref="worldBox"/>

--- a/gdml/BabyIAXO/CompleteVeto3Layers.gdml
+++ b/gdml/BabyIAXO/CompleteVeto3Layers.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3677,12 +3679,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4122,7 +4158,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/BabyIAXO/CompleteVeto4Layers.gdml
+++ b/gdml/BabyIAXO/CompleteVeto4Layers.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3663,6 +3669,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3697,324 +3719,324 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-800.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-800.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-800.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266210">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266211">
+            <physvol name="captureLayerVolume-800.0mm-73266211">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266211.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266212.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+            <physvol name="assembly-6.veto1">
                 <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop1.position" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop2">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop2.position" y="74.0" unit="mm"/>
                 <rotation name="vetoLayerTop2.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop3">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop3.position" y="148.0" unit="mm"/>
                 <rotation name="vetoLayerTop3.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop4">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop4.position" y="222.0" unit="mm"/>
                 <rotation name="vetoLayerTop4.rotation" y="180.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto4">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-9">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto4">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-10">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom1.position" y="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom2">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom2.position" y="-54.0" unit="mm"/>
                 <rotation name="vetoLayerBottom2.rotation" y="540.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom3">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom3.position" y="-108.0" unit="mm"/>
                 <rotation name="vetoLayerBottom3.rotation" y="720.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom4">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom4.position" y="-162.0" unit="mm"/>
                 <rotation name="vetoLayerBottom4.rotation" y="900.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-10">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df66">
+        <assembly name="assembly-11">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df67">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df67">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df68">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df68">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-11">
-            <physvol name="assembly-11.veto1">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto2">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto3">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto4">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-12">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-12.veto1">
                 <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto2">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto3">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto4">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-13">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight2">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight2.position" x="-74.0" unit="mm"/>
                 <rotation name="vetoLayerRight2.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight3">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight3.position" x="-148.0" unit="mm"/>
                 <rotation name="vetoLayerRight3.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight4">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight4.position" x="-222.0" unit="mm"/>
                 <rotation name="vetoLayerRight4.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-13">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df69">
+        <assembly name="assembly-14">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6a">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6a">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6b">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6c">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6d">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6d">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6d.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6d.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-14">
-            <physvol name="assembly-14.veto1">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto2">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto3">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto4">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6e.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-15">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-15.veto1">
                 <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto2">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto3">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto4">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-16">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft2">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft2.position" x="74.0" unit="mm"/>
                 <rotation name="vetoLayerLeft2.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft3">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft3.position" x="148.0" unit="mm"/>
                 <rotation name="vetoLayerLeft3.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft4">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft4.position" x="222.0" unit="mm"/>
                 <rotation name="vetoLayerLeft4.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-16">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6c">
+        <assembly name="assembly-17">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6d">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6d">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6e">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6f">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df70">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df71">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df70.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-17">
-            <physvol name="assembly-17.veto1">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto2">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto3">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto4">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df71.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-18">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-18.veto1">
                 <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto2">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto3">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto4">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-19">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack1.position" y="80.0" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack2">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack2.position" y="80.0" z="-74.0" unit="mm"/>
                 <rotation name="vetoLayerBack2.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack3">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack3.position" y="80.0" z="-148.0" unit="mm"/>
                 <rotation name="vetoLayerBack3.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack4">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack4.position" y="80.0" z="-222.0" unit="mm"/>
                 <rotation name="vetoLayerBack4.rotation" x="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-19">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
+        <assembly name="assembly-20">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df85">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df86">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df71">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df87">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df89">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df89.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-300.0mm">
@@ -4033,90 +4055,90 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-300.0mm"/>
         </volume>
-        <assembly name="assembly-20">
-            <physvol name="scintillatorVolume-300.0mm-f1a5df85">
+        <assembly name="assembly-21">
+            <physvol name="scintillatorVolume-300.0mm-f1a5df86">
                 <volumeref ref="scintillatorVolume-300.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df86">
+            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df87">
                 <volumeref ref="scintillatorWrappingSolid-300.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-300.0mm-f1a5df87">
-                <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-300.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df89">
+            <physvol name="captureLayerVolume-300.0mm-f1a5df89">
+                <volumeref ref="captureLayerVolume-300.0mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df8a">
                 <volumeref ref="scintillatorLightGuideVolume-300.0mm"/>
-                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df89.position" z="-215.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df8a.position" z="-215.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
+        <assembly name="assembly-22">
             <physvol name="veto0">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto0.position" x="-207.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmall1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmall1.position" z="-250.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmallRotated1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmallRotated1.position" z="250.0" unit="mm"/>
                 <rotation name="vetoSmallRotated1.rotation" x="180.0" unit="deg"/>
             </physvol>
             <physvol name="veto2">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto2.position" x="207.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-22">
+        <assembly name="assembly-23">
             <physvol name="vetoLayerFront1">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront2">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront2.position" z="74.0" unit="mm"/>
                 <rotation name="vetoLayerFront2.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront3">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront3.position" z="148.0" unit="mm"/>
                 <rotation name="vetoLayerFront3.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront4">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront4.position" z="222.0" unit="mm"/>
                 <rotation name="vetoLayerFront4.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-9"/>
+                <volumeref ref="assembly-10"/>
                 <position name="vetoSystemBottom.position" y="-357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-12"/>
+                <volumeref ref="assembly-13"/>
                 <position name="vetoSystemRight.position" x="-467.0" z="-10.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-15"/>
+                <volumeref ref="assembly-16"/>
                 <position name="vetoSystemLeft.position" x="467.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-18"/>
+                <volumeref ref="assembly-19"/>
                 <position name="vetoSystemBack.position" y="80.0" z="-422.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoSystemFront.position" z="461.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4128,11 +4150,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
             </physvol>
             <materialref ref="G4_AIR"/>
             <solidref ref="worldBox"/>

--- a/gdml/BabyIAXO/CompleteVeto4Layers.gdml
+++ b/gdml/BabyIAXO/CompleteVeto4Layers.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3677,12 +3679,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4152,7 +4188,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/BabyIAXO/Default.gdml
+++ b/gdml/BabyIAXO/Default.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3663,6 +3669,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3697,299 +3719,299 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-800.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-800.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-800.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266210">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266211">
+            <physvol name="captureLayerVolume-800.0mm-73266211">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266211.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266212.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+            <physvol name="assembly-6.veto1">
                 <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop1.position" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop2">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop2.position" y="74.0" unit="mm"/>
                 <rotation name="vetoLayerTop2.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop3">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop3.position" y="148.0" unit="mm"/>
                 <rotation name="vetoLayerTop3.rotation" y="180.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto4">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-9">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto4">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-10">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom1.position" y="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom2">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom2.position" y="-54.0" unit="mm"/>
                 <rotation name="vetoLayerBottom2.rotation" y="540.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom3">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom3.position" y="-108.0" unit="mm"/>
                 <rotation name="vetoLayerBottom3.rotation" y="720.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-10">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df66">
+        <assembly name="assembly-11">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df67">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df67">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df68">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df68">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-11">
-            <physvol name="assembly-11.veto1">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto2">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto3">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto4">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-12">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-12.veto1">
                 <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto2">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto3">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto4">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-13">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight2">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight2.position" x="-74.0" unit="mm"/>
                 <rotation name="vetoLayerRight2.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight3">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight3.position" x="-148.0" unit="mm"/>
                 <rotation name="vetoLayerRight3.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-13">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df69">
+        <assembly name="assembly-14">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6a">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6a">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6b">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6c">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6d">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6d">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6d.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6d.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-14">
-            <physvol name="assembly-14.veto1">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto2">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto3">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto4">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6e.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-15">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-15.veto1">
                 <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto2">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto3">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto4">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-16">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft2">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft2.position" x="74.0" unit="mm"/>
                 <rotation name="vetoLayerLeft2.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft3">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft3.position" x="148.0" unit="mm"/>
                 <rotation name="vetoLayerLeft3.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-16">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6c">
+        <assembly name="assembly-17">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6d">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6d">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6e">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6f">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df70">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df71">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df70.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-17">
-            <physvol name="assembly-17.veto1">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto2">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto3">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto4">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df71.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-18">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-18.veto1">
                 <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto2">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto3">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto4">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-19">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack1.position" y="80.0" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack2">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack2.position" y="80.0" z="-74.0" unit="mm"/>
                 <rotation name="vetoLayerBack2.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack3">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack3.position" y="80.0" z="-148.0" unit="mm"/>
                 <rotation name="vetoLayerBack3.rotation" x="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-19">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
+        <assembly name="assembly-20">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df85">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df86">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df71">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df87">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df89">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df89.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-300.0mm">
@@ -4008,85 +4030,85 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-300.0mm"/>
         </volume>
-        <assembly name="assembly-20">
-            <physvol name="scintillatorVolume-300.0mm-f1a5df85">
+        <assembly name="assembly-21">
+            <physvol name="scintillatorVolume-300.0mm-f1a5df86">
                 <volumeref ref="scintillatorVolume-300.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df86">
+            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df87">
                 <volumeref ref="scintillatorWrappingSolid-300.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-300.0mm-f1a5df87">
-                <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-300.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df89">
+            <physvol name="captureLayerVolume-300.0mm-f1a5df89">
+                <volumeref ref="captureLayerVolume-300.0mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df8a">
                 <volumeref ref="scintillatorLightGuideVolume-300.0mm"/>
-                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df89.position" z="-215.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df8a.position" z="-215.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
+        <assembly name="assembly-22">
             <physvol name="veto0">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto0.position" x="-207.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmall1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmall1.position" z="-250.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmallRotated1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmallRotated1.position" z="250.0" unit="mm"/>
                 <rotation name="vetoSmallRotated1.rotation" x="180.0" unit="deg"/>
             </physvol>
             <physvol name="veto2">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto2.position" x="207.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-22">
+        <assembly name="assembly-23">
             <physvol name="vetoLayerFront1">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront2">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront2.position" z="74.0" unit="mm"/>
                 <rotation name="vetoLayerFront2.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront3">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront3.position" z="148.0" unit="mm"/>
                 <rotation name="vetoLayerFront3.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-9"/>
+                <volumeref ref="assembly-10"/>
                 <position name="vetoSystemBottom.position" y="-357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-12"/>
+                <volumeref ref="assembly-13"/>
                 <position name="vetoSystemRight.position" x="-467.0" z="-10.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-15"/>
+                <volumeref ref="assembly-16"/>
                 <position name="vetoSystemLeft.position" x="467.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-18"/>
+                <volumeref ref="assembly-19"/>
                 <position name="vetoSystemBack.position" y="80.0" z="-422.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoSystemFront.position" z="461.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4098,11 +4120,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
             </physvol>
             <materialref ref="G4_AIR"/>
             <solidref ref="worldBox"/>

--- a/gdml/BabyIAXO/Default.gdml
+++ b/gdml/BabyIAXO/Default.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3677,12 +3679,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4122,7 +4158,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/BabyIAXO/DefaultXenon.gdml
+++ b/gdml/BabyIAXO/DefaultXenon.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3663,6 +3669,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3697,299 +3719,299 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-800.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-800.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-800.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266210">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266211">
+            <physvol name="captureLayerVolume-800.0mm-73266211">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266211.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266212.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+            <physvol name="assembly-6.veto1">
                 <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop1.position" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop2">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop2.position" y="74.0" unit="mm"/>
                 <rotation name="vetoLayerTop2.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop3">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop3.position" y="148.0" unit="mm"/>
                 <rotation name="vetoLayerTop3.rotation" y="180.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto4">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-9">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto4">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-10">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom1.position" y="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom2">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom2.position" y="-54.0" unit="mm"/>
                 <rotation name="vetoLayerBottom2.rotation" y="540.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom3">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom3.position" y="-108.0" unit="mm"/>
                 <rotation name="vetoLayerBottom3.rotation" y="720.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-10">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df66">
+        <assembly name="assembly-11">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df67">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df67">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df68">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df68">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-11">
-            <physvol name="assembly-11.veto1">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto2">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto3">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto4">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-12">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-12.veto1">
                 <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto2">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto3">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto4">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-13">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight2">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight2.position" x="-74.0" unit="mm"/>
                 <rotation name="vetoLayerRight2.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight3">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight3.position" x="-148.0" unit="mm"/>
                 <rotation name="vetoLayerRight3.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-13">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df69">
+        <assembly name="assembly-14">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6a">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6a">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6b">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6c">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6d">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6d">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6d.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6d.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-14">
-            <physvol name="assembly-14.veto1">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto2">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto3">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto4">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6e.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-15">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-15.veto1">
                 <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto2">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto3">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto4">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-16">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft2">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft2.position" x="74.0" unit="mm"/>
                 <rotation name="vetoLayerLeft2.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft3">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft3.position" x="148.0" unit="mm"/>
                 <rotation name="vetoLayerLeft3.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-16">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6c">
+        <assembly name="assembly-17">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6d">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6d">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6e">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6f">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df70">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df71">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df70.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-17">
-            <physvol name="assembly-17.veto1">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto2">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto3">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto4">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df71.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-18">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-18.veto1">
                 <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto2">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto3">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto4">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-19">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack1.position" y="80.0" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack2">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack2.position" y="80.0" z="-74.0" unit="mm"/>
                 <rotation name="vetoLayerBack2.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack3">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack3.position" y="80.0" z="-148.0" unit="mm"/>
                 <rotation name="vetoLayerBack3.rotation" x="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-19">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
+        <assembly name="assembly-20">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df85">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df86">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df71">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df87">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df89">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df89.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-300.0mm">
@@ -4008,85 +4030,85 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-300.0mm"/>
         </volume>
-        <assembly name="assembly-20">
-            <physvol name="scintillatorVolume-300.0mm-f1a5df85">
+        <assembly name="assembly-21">
+            <physvol name="scintillatorVolume-300.0mm-f1a5df86">
                 <volumeref ref="scintillatorVolume-300.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df86">
+            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df87">
                 <volumeref ref="scintillatorWrappingSolid-300.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-300.0mm-f1a5df87">
-                <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-300.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df89">
+            <physvol name="captureLayerVolume-300.0mm-f1a5df89">
+                <volumeref ref="captureLayerVolume-300.0mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df8a">
                 <volumeref ref="scintillatorLightGuideVolume-300.0mm"/>
-                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df89.position" z="-215.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df8a.position" z="-215.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
+        <assembly name="assembly-22">
             <physvol name="veto0">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto0.position" x="-207.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmall1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmall1.position" z="-250.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmallRotated1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmallRotated1.position" z="250.0" unit="mm"/>
                 <rotation name="vetoSmallRotated1.rotation" x="180.0" unit="deg"/>
             </physvol>
             <physvol name="veto2">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto2.position" x="207.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-22">
+        <assembly name="assembly-23">
             <physvol name="vetoLayerFront1">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront2">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront2.position" z="74.0" unit="mm"/>
                 <rotation name="vetoLayerFront2.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront3">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront3.position" z="148.0" unit="mm"/>
                 <rotation name="vetoLayerFront3.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-9"/>
+                <volumeref ref="assembly-10"/>
                 <position name="vetoSystemBottom.position" y="-357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-12"/>
+                <volumeref ref="assembly-13"/>
                 <position name="vetoSystemRight.position" x="-467.0" z="-10.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-15"/>
+                <volumeref ref="assembly-16"/>
                 <position name="vetoSystemLeft.position" x="467.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-18"/>
+                <volumeref ref="assembly-19"/>
                 <position name="vetoSystemBack.position" y="80.0" z="-422.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoSystemFront.position" z="461.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4098,11 +4120,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
             </physvol>
             <materialref ref="G4_AIR"/>
             <solidref ref="worldBox"/>

--- a/gdml/BabyIAXO/DefaultXenon.gdml
+++ b/gdml/BabyIAXO/DefaultXenon.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3677,12 +3679,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4122,7 +4158,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/BabyIAXO/NoVetos.gdml
+++ b/gdml/BabyIAXO/NoVetos.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3636,12 +3638,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -3672,7 +3708,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/BabyIAXO/NoVetos.gdml
+++ b/gdml/BabyIAXO/NoVetos.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3622,6 +3628,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3647,6 +3669,10 @@
             <physvol name="DetectorPipe">
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
+            </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/BabyIAXO/ShieldingLayers.gdml
+++ b/gdml/BabyIAXO/ShieldingLayers.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="shieldingLayerBox1" x="220.0" y="220.0" z="360.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerHole1" x="200.0" y="200.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="shieldingLayerBoxWithHole1">
@@ -3755,6 +3761,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="shieldingVolumeLayer1">
             <materialref ref="G4_Pb"/>
             <solidref ref="shieldingLayerBoxWithHole1"/>
@@ -3932,6 +3954,10 @@
             <physvol name="DetectorPipe">
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
+            </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/BabyIAXO/ShieldingLayers.gdml
+++ b/gdml/BabyIAXO/ShieldingLayers.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerBox1" x="220.0" y="220.0" z="360.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerHole1" x="200.0" y="200.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="shieldingLayerBoxWithHole1">
@@ -3769,12 +3771,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="shieldingVolumeLayer1">
@@ -3957,7 +3993,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/BabyIAXO/ShieldingLayersNoCopperBox.gdml
+++ b/gdml/BabyIAXO/ShieldingLayersNoCopperBox.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerBox1" x="220.0" y="220.0" z="360.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerHole1" x="200.0" y="200.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="shieldingLayerBoxWithHole1">
@@ -3769,12 +3771,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="shieldingVolumeLayer1">
@@ -3953,7 +3989,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/BabyIAXO/ShieldingLayersNoCopperBox.gdml
+++ b/gdml/BabyIAXO/ShieldingLayersNoCopperBox.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="shieldingLayerBox1" x="220.0" y="220.0" z="360.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerHole1" x="200.0" y="200.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="shieldingLayerBoxWithHole1">
@@ -3755,6 +3761,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="shieldingVolumeLayer1">
             <materialref ref="G4_Pb"/>
             <solidref ref="shieldingLayerBoxWithHole1"/>
@@ -3928,6 +3950,10 @@
             <physvol name="DetectorPipe">
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
+            </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/BabyIAXO/WithTelescopePipe.gdml
+++ b/gdml/BabyIAXO/WithTelescopePipe.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3671,6 +3677,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3705,299 +3727,299 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-800.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-800.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-800.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266210">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266211">
+            <physvol name="captureLayerVolume-800.0mm-73266211">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266211.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266212.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+            <physvol name="assembly-6.veto1">
                 <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop1.position" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop2">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop2.position" y="74.0" unit="mm"/>
                 <rotation name="vetoLayerTop2.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop3">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop3.position" y="148.0" unit="mm"/>
                 <rotation name="vetoLayerTop3.rotation" y="180.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto4">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-9">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto4">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-10">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom1.position" y="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom2">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom2.position" y="-54.0" unit="mm"/>
                 <rotation name="vetoLayerBottom2.rotation" y="540.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom3">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom3.position" y="-108.0" unit="mm"/>
                 <rotation name="vetoLayerBottom3.rotation" y="720.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-10">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df66">
+        <assembly name="assembly-11">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df67">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df67">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df68">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df68">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-11">
-            <physvol name="assembly-11.veto1">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto2">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto3">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto4">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-12">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-12.veto1">
                 <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto2">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto3">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto4">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-13">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight2">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight2.position" x="-74.0" unit="mm"/>
                 <rotation name="vetoLayerRight2.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight3">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight3.position" x="-148.0" unit="mm"/>
                 <rotation name="vetoLayerRight3.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-13">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df69">
+        <assembly name="assembly-14">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6a">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6a">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6b">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6c">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6d">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6d">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6d.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6d.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-14">
-            <physvol name="assembly-14.veto1">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto2">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto3">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto4">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6e.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-15">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-15.veto1">
                 <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto2">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto3">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto4">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-16">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft2">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft2.position" x="74.0" unit="mm"/>
                 <rotation name="vetoLayerLeft2.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft3">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft3.position" x="148.0" unit="mm"/>
                 <rotation name="vetoLayerLeft3.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-16">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6c">
+        <assembly name="assembly-17">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6d">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6d">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6e">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6f">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df70">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df71">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df70.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-17">
-            <physvol name="assembly-17.veto1">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto2">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto3">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto4">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df71.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-18">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-18.veto1">
                 <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto2">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto3">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto4">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-19">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack1.position" y="80.0" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack2">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack2.position" y="80.0" z="-74.0" unit="mm"/>
                 <rotation name="vetoLayerBack2.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack3">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack3.position" y="80.0" z="-148.0" unit="mm"/>
                 <rotation name="vetoLayerBack3.rotation" x="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-19">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
+        <assembly name="assembly-20">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df85">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df86">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df71">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df87">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df89">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df89.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-300.0mm">
@@ -4016,85 +4038,85 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-300.0mm"/>
         </volume>
-        <assembly name="assembly-20">
-            <physvol name="scintillatorVolume-300.0mm-f1a5df85">
+        <assembly name="assembly-21">
+            <physvol name="scintillatorVolume-300.0mm-f1a5df86">
                 <volumeref ref="scintillatorVolume-300.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df86">
+            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df87">
                 <volumeref ref="scintillatorWrappingSolid-300.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-300.0mm-f1a5df87">
-                <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-300.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df89">
+            <physvol name="captureLayerVolume-300.0mm-f1a5df89">
+                <volumeref ref="captureLayerVolume-300.0mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df8a">
                 <volumeref ref="scintillatorLightGuideVolume-300.0mm"/>
-                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df89.position" z="-215.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df8a.position" z="-215.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
+        <assembly name="assembly-22">
             <physvol name="veto0">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto0.position" x="-207.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmall1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmall1.position" z="-250.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmallRotated1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmallRotated1.position" z="250.0" unit="mm"/>
                 <rotation name="vetoSmallRotated1.rotation" x="180.0" unit="deg"/>
             </physvol>
             <physvol name="veto2">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto2.position" x="207.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-22">
+        <assembly name="assembly-23">
             <physvol name="vetoLayerFront1">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront2">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront2.position" z="74.0" unit="mm"/>
                 <rotation name="vetoLayerFront2.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront3">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront3.position" z="148.0" unit="mm"/>
                 <rotation name="vetoLayerFront3.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-9"/>
+                <volumeref ref="assembly-10"/>
                 <position name="vetoSystemBottom.position" y="-357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-12"/>
+                <volumeref ref="assembly-13"/>
                 <position name="vetoSystemRight.position" x="-467.0" z="-10.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-15"/>
+                <volumeref ref="assembly-16"/>
                 <position name="vetoSystemLeft.position" x="467.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-18"/>
+                <volumeref ref="assembly-19"/>
                 <position name="vetoSystemBack.position" y="80.0" z="-422.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoSystemFront.position" z="461.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4132,11 +4154,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
             </physvol>
             <physvol name="TelescopePipe">
                 <volumeref ref="telescopePipe"/>

--- a/gdml/BabyIAXO/WithTelescopePipe.gdml
+++ b/gdml/BabyIAXO/WithTelescopePipe.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3685,12 +3687,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4156,7 +4192,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/IAXO-D1/ChamberAndPipe.gdml
+++ b/gdml/IAXO-D1/ChamberAndPipe.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="worldBox" x="1350.0" y="1350.0" z="3000.0"/>
     </solids>
     <structure>
@@ -3622,12 +3624,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="world">
@@ -3640,7 +3676,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <materialref ref="G4_AIR"/>
             <solidref ref="worldBox"/>

--- a/gdml/IAXO-D1/ChamberAndPipe.gdml
+++ b/gdml/IAXO-D1/ChamberAndPipe.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="worldBox" x="1350.0" y="1350.0" z="3000.0"/>
     </solids>
     <structure>
@@ -3608,6 +3614,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="world">
             <physvol name="Chamber">
                 <volumeref ref="Chamber"/>
@@ -3615,6 +3637,10 @@
             <physvol name="DetectorPipe">
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
+            </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
             </physvol>
             <materialref ref="G4_AIR"/>
             <solidref ref="worldBox"/>

--- a/gdml/IAXO-D1/CompleteVeto1Layers.gdml
+++ b/gdml/IAXO-D1/CompleteVeto1Layers.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3663,6 +3669,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3697,42 +3719,42 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-1500.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-1500.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-1500.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-73266210">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266211">
+            <physvol name="captureLayerVolume-1500.0mm-73266211">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-73266211.position" z="-815.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-73266212.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
+        <assembly name="assembly-6">
+            <physvol name="assembly-6.veto1">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-800.0mm">
@@ -3751,279 +3773,279 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-207.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="207.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+        <assembly name="assembly-9">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-207.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="207.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerTop1.position" y="-35.0" z="-240.0" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-9">
-            <physvol name="scintillatorVolume-1500.0mm-73266212">
+        <assembly name="assembly-10">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df66">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-73266213">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df67">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-73266214">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df68">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266214.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-73266215">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266215.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266216">
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6a">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-73266216.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-10">
-            <physvol name="assembly-10.veto1">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto2">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto3">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto4">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6a.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-11">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-11.veto1">
                 <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto2">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto3">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto4">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-12">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom1.position" y="20.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-12">
-            <physvol name="scintillatorVolume-1500.0mm-f1a5df68">
+        <assembly name="assembly-13">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df69">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df69">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6a">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-f1a5df6a">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6a.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-f1a5df6b">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6b.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6c">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6c">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6d">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6c.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-13">
-            <physvol name="assembly-13.veto1">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-13.veto2">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-13.veto3">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6d.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-14">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-14.veto1">
                 <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-14.veto2">
+                <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-14.veto3">
+                <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-15">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-15">
-            <physvol name="scintillatorVolume-1500.0mm-f1a5df6b">
+        <assembly name="assembly-16">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df6c">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6c">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6d">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-f1a5df6d">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6d.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-f1a5df6e">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6e.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6f">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6f">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df70">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6f.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-16">
-            <physvol name="assembly-16.veto1">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-16.veto2">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-16.veto3">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df70.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-17">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-17.veto1">
                 <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-17.veto2">
+                <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-17.veto3">
+                <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-18">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-18">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6e">
+        <assembly name="assembly-19">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6f">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df71">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df72.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-19">
-            <physvol name="assembly-19.veto1">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-19.veto2">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-19.veto3">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-20">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-20.veto1">
                 <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-20.veto2">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-20.veto3">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-21">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack1.position" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df86">
+        <assembly name="assembly-22">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df87">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df87">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df88">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df89">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df89.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df8a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df8a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df8a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df8b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df8a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-22">
-            <physvol name="assembly-22.veto1">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-22.veto2">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-22.veto3">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df8b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-23">
-            <physvol name="vetoLayerFront1">
+            <physvol name="assembly-23.veto1">
                 <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-23.veto2">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-23.veto3">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-24">
+            <physvol name="vetoLayerFront1">
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="327.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoSystemBottom.position" y="-437.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoSystemRight.position" x="-387.0" z="119.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoSystemLeft.position" x="387.0" z="-80.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSystemBack.position" x="-65.0" z="-692.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-23"/>
+                <volumeref ref="assembly-24"/>
                 <position name="vetoSystemFront.position" x="65.0" z="711.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4035,11 +4057,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
                 <position name="VetoSystem.position" y="40.0" z="400.0" unit="mm"/>
             </physvol>
             <materialref ref="G4_AIR"/>

--- a/gdml/IAXO-D1/CompleteVeto1Layers.gdml
+++ b/gdml/IAXO-D1/CompleteVeto1Layers.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3677,12 +3679,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4059,7 +4095,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/IAXO-D1/CompleteVeto2Layers.gdml
+++ b/gdml/IAXO-D1/CompleteVeto2Layers.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3663,6 +3669,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3697,42 +3719,42 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-1500.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-1500.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-1500.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-73266210">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266211">
+            <physvol name="captureLayerVolume-1500.0mm-73266211">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-73266211.position" z="-815.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-73266212.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
+        <assembly name="assembly-6">
+            <physvol name="assembly-6.veto1">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-800.0mm">
@@ -3751,309 +3773,309 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-207.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="207.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+        <assembly name="assembly-9">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-207.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="207.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerTop1.position" y="-35.0" z="-240.0" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop2">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop2.position" y="59.0" unit="mm"/>
                 <rotation name="vetoLayerTop2.rotation" y="360.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-9">
-            <physvol name="scintillatorVolume-1500.0mm-73266212">
+        <assembly name="assembly-10">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df66">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-73266213">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df67">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-73266214">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df68">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266214.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-73266215">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266215.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266216">
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6a">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-73266216.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-10">
-            <physvol name="assembly-10.veto1">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto2">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto3">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto4">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6a.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-11">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-11.veto1">
                 <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto2">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto3">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto4">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-12">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom1.position" y="20.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom2">
-                <volumeref ref="assembly-10"/>
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom2.position" y="-59.0" unit="mm"/>
                 <rotation name="vetoLayerBottom2.rotation" y="540.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-12">
-            <physvol name="scintillatorVolume-1500.0mm-f1a5df68">
+        <assembly name="assembly-13">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df69">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df69">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6a">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-f1a5df6a">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6a.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-f1a5df6b">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6b.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6c">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6c">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6d">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6c.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-13">
-            <physvol name="assembly-13.veto1">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-13.veto2">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-13.veto3">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6d.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-14">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-14.veto1">
                 <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-14.veto2">
+                <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-14.veto3">
+                <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-15">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight2">
-                <volumeref ref="assembly-13"/>
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight2.position" x="-74.0" unit="mm"/>
                 <rotation name="vetoLayerRight2.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-15">
-            <physvol name="scintillatorVolume-1500.0mm-f1a5df6b">
+        <assembly name="assembly-16">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df6c">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6c">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6d">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-f1a5df6d">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6d.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-f1a5df6e">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6e.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6f">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6f">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df70">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6f.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-16">
-            <physvol name="assembly-16.veto1">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-16.veto2">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-16.veto3">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df70.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-17">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-17.veto1">
                 <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-17.veto2">
+                <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-17.veto3">
+                <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-18">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft2">
-                <volumeref ref="assembly-16"/>
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft2.position" x="74.0" unit="mm"/>
                 <rotation name="vetoLayerLeft2.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-18">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6e">
+        <assembly name="assembly-19">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6f">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df71">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df72.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-19">
-            <physvol name="assembly-19.veto1">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-19.veto2">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-19.veto3">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-20">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-20.veto1">
                 <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-20.veto2">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-20.veto3">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-21">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack1.position" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack2">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack2.position" z="-74.0" unit="mm"/>
                 <rotation name="vetoLayerBack2.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df86">
+        <assembly name="assembly-22">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df87">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df87">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df88">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df89">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df89.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df8a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df8a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df8a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df8b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df8a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-22">
-            <physvol name="assembly-22.veto1">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-22.veto2">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-22.veto3">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df8b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-23">
-            <physvol name="vetoLayerFront1">
+            <physvol name="assembly-23.veto1">
                 <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-23.veto2">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-23.veto3">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-24">
+            <physvol name="vetoLayerFront1">
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront2">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront2.position" z="74.0" unit="mm"/>
                 <rotation name="vetoLayerFront2.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="327.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoSystemBottom.position" y="-437.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoSystemRight.position" x="-387.0" z="119.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoSystemLeft.position" x="387.0" z="-80.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSystemBack.position" x="-65.0" z="-692.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-23"/>
+                <volumeref ref="assembly-24"/>
                 <position name="vetoSystemFront.position" x="65.0" z="711.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4065,11 +4087,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
                 <position name="VetoSystem.position" y="40.0" z="400.0" unit="mm"/>
             </physvol>
             <materialref ref="G4_AIR"/>

--- a/gdml/IAXO-D1/CompleteVeto2Layers.gdml
+++ b/gdml/IAXO-D1/CompleteVeto2Layers.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3677,12 +3679,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4089,7 +4125,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/IAXO-D1/CompleteVeto3Layers.gdml
+++ b/gdml/IAXO-D1/CompleteVeto3Layers.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3677,12 +3679,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4119,7 +4155,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/IAXO-D1/CompleteVeto3Layers.gdml
+++ b/gdml/IAXO-D1/CompleteVeto3Layers.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3663,6 +3669,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3697,42 +3719,42 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-1500.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-1500.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-1500.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-73266210">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266211">
+            <physvol name="captureLayerVolume-1500.0mm-73266211">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-73266211.position" z="-815.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-73266212.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
+        <assembly name="assembly-6">
+            <physvol name="assembly-6.veto1">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-800.0mm">
@@ -3751,339 +3773,339 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-207.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="207.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+        <assembly name="assembly-9">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-207.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="207.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerTop1.position" y="-35.0" z="-240.0" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop2">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop2.position" y="59.0" unit="mm"/>
                 <rotation name="vetoLayerTop2.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop3">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop3.position" y="118.0" unit="mm"/>
                 <rotation name="vetoLayerTop3.rotation" y="540.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-9">
-            <physvol name="scintillatorVolume-1500.0mm-73266212">
+        <assembly name="assembly-10">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df66">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-73266213">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df67">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-73266214">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df68">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266214.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-73266215">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266215.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266216">
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6a">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-73266216.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-10">
-            <physvol name="assembly-10.veto1">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto2">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto3">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto4">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6a.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-11">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-11.veto1">
                 <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto2">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto3">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto4">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-12">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom1.position" y="20.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom2">
-                <volumeref ref="assembly-10"/>
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom2.position" y="-59.0" unit="mm"/>
                 <rotation name="vetoLayerBottom2.rotation" y="540.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom3">
-                <volumeref ref="assembly-10"/>
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom3.position" y="-118.0" unit="mm"/>
                 <rotation name="vetoLayerBottom3.rotation" y="720.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-12">
-            <physvol name="scintillatorVolume-1500.0mm-f1a5df68">
+        <assembly name="assembly-13">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df69">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df69">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6a">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-f1a5df6a">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6a.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-f1a5df6b">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6b.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6c">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6c">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6d">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6c.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-13">
-            <physvol name="assembly-13.veto1">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-13.veto2">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-13.veto3">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6d.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-14">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-14.veto1">
                 <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-14.veto2">
+                <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-14.veto3">
+                <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-15">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight2">
-                <volumeref ref="assembly-13"/>
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight2.position" x="-74.0" unit="mm"/>
                 <rotation name="vetoLayerRight2.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight3">
-                <volumeref ref="assembly-13"/>
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight3.position" x="-148.0" unit="mm"/>
                 <rotation name="vetoLayerRight3.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-15">
-            <physvol name="scintillatorVolume-1500.0mm-f1a5df6b">
+        <assembly name="assembly-16">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df6c">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6c">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6d">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-f1a5df6d">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6d.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-f1a5df6e">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6e.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6f">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6f">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df70">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6f.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-16">
-            <physvol name="assembly-16.veto1">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-16.veto2">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-16.veto3">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df70.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-17">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-17.veto1">
                 <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-17.veto2">
+                <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-17.veto3">
+                <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-18">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft2">
-                <volumeref ref="assembly-16"/>
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft2.position" x="74.0" unit="mm"/>
                 <rotation name="vetoLayerLeft2.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft3">
-                <volumeref ref="assembly-16"/>
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft3.position" x="148.0" unit="mm"/>
                 <rotation name="vetoLayerLeft3.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-18">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6e">
+        <assembly name="assembly-19">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6f">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df71">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df72.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-19">
-            <physvol name="assembly-19.veto1">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-19.veto2">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-19.veto3">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-20">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-20.veto1">
                 <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-20.veto2">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-20.veto3">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-21">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack1.position" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack2">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack2.position" z="-74.0" unit="mm"/>
                 <rotation name="vetoLayerBack2.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack3">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack3.position" z="-148.0" unit="mm"/>
                 <rotation name="vetoLayerBack3.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df86">
+        <assembly name="assembly-22">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df87">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df87">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df88">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df89">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df89.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df8a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df8a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df8a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df8b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df8a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-22">
-            <physvol name="assembly-22.veto1">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-22.veto2">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-22.veto3">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df8b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-23">
-            <physvol name="vetoLayerFront1">
+            <physvol name="assembly-23.veto1">
                 <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-23.veto2">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-23.veto3">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-24">
+            <physvol name="vetoLayerFront1">
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront2">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront2.position" z="74.0" unit="mm"/>
                 <rotation name="vetoLayerFront2.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront3">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront3.position" z="148.0" unit="mm"/>
                 <rotation name="vetoLayerFront3.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="327.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoSystemBottom.position" y="-437.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoSystemRight.position" x="-387.0" z="119.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoSystemLeft.position" x="387.0" z="-80.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSystemBack.position" x="-65.0" z="-692.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-23"/>
+                <volumeref ref="assembly-24"/>
                 <position name="vetoSystemFront.position" x="65.0" z="711.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4095,11 +4117,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
                 <position name="VetoSystem.position" y="40.0" z="400.0" unit="mm"/>
             </physvol>
             <materialref ref="G4_AIR"/>

--- a/gdml/IAXO-D1/CompleteVeto4Layers.gdml
+++ b/gdml/IAXO-D1/CompleteVeto4Layers.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3663,6 +3669,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3697,42 +3719,42 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-1500.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-1500.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-1500.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-73266210">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266211">
+            <physvol name="captureLayerVolume-1500.0mm-73266211">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-73266211.position" z="-815.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-73266212.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
+        <assembly name="assembly-6">
+            <physvol name="assembly-6.veto1">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-800.0mm">
@@ -3751,369 +3773,369 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-207.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="207.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+        <assembly name="assembly-9">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-207.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="207.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerTop1.position" y="-35.0" z="-240.0" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop2">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop2.position" y="59.0" unit="mm"/>
                 <rotation name="vetoLayerTop2.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop3">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop3.position" y="118.0" unit="mm"/>
                 <rotation name="vetoLayerTop3.rotation" y="540.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop4">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop4.position" y="177.0" unit="mm"/>
                 <rotation name="vetoLayerTop4.rotation" y="720.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-9">
-            <physvol name="scintillatorVolume-1500.0mm-73266212">
+        <assembly name="assembly-10">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df66">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-73266213">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df67">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-73266214">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df68">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266214.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-73266215">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266215.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266216">
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6a">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-73266216.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-10">
-            <physvol name="assembly-10.veto1">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto2">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto3">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto4">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6a.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-11">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-11.veto1">
                 <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto2">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto3">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto4">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-12">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom1.position" y="20.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom2">
-                <volumeref ref="assembly-10"/>
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom2.position" y="-59.0" unit="mm"/>
                 <rotation name="vetoLayerBottom2.rotation" y="540.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom3">
-                <volumeref ref="assembly-10"/>
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom3.position" y="-118.0" unit="mm"/>
                 <rotation name="vetoLayerBottom3.rotation" y="720.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom4">
-                <volumeref ref="assembly-10"/>
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom4.position" y="-177.0" unit="mm"/>
                 <rotation name="vetoLayerBottom4.rotation" y="900.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-12">
-            <physvol name="scintillatorVolume-1500.0mm-f1a5df68">
+        <assembly name="assembly-13">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df69">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df69">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6a">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-f1a5df6a">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6a.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-f1a5df6b">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6b.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6c">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6c">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6d">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6c.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-13">
-            <physvol name="assembly-13.veto1">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-13.veto2">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-13.veto3">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6d.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-14">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-14.veto1">
                 <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-14.veto2">
+                <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-14.veto3">
+                <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-15">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight2">
-                <volumeref ref="assembly-13"/>
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight2.position" x="-74.0" unit="mm"/>
                 <rotation name="vetoLayerRight2.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight3">
-                <volumeref ref="assembly-13"/>
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight3.position" x="-148.0" unit="mm"/>
                 <rotation name="vetoLayerRight3.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight4">
-                <volumeref ref="assembly-13"/>
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight4.position" x="-222.0" unit="mm"/>
                 <rotation name="vetoLayerRight4.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-15">
-            <physvol name="scintillatorVolume-1500.0mm-f1a5df6b">
+        <assembly name="assembly-16">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df6c">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6c">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6d">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-f1a5df6d">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6d.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-f1a5df6e">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6e.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6f">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6f">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df70">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6f.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-16">
-            <physvol name="assembly-16.veto1">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-16.veto2">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-16.veto3">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df70.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-17">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-17.veto1">
                 <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-17.veto2">
+                <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-17.veto3">
+                <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-18">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft2">
-                <volumeref ref="assembly-16"/>
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft2.position" x="74.0" unit="mm"/>
                 <rotation name="vetoLayerLeft2.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft3">
-                <volumeref ref="assembly-16"/>
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft3.position" x="148.0" unit="mm"/>
                 <rotation name="vetoLayerLeft3.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft4">
-                <volumeref ref="assembly-16"/>
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft4.position" x="222.0" unit="mm"/>
                 <rotation name="vetoLayerLeft4.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-18">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6e">
+        <assembly name="assembly-19">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6f">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df71">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df72.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-19">
-            <physvol name="assembly-19.veto1">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-19.veto2">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-19.veto3">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-20">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-20.veto1">
                 <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-20.veto2">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-20.veto3">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-21">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack1.position" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack2">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack2.position" z="-74.0" unit="mm"/>
                 <rotation name="vetoLayerBack2.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack3">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack3.position" z="-148.0" unit="mm"/>
                 <rotation name="vetoLayerBack3.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack4">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack4.position" z="-222.0" unit="mm"/>
                 <rotation name="vetoLayerBack4.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df86">
+        <assembly name="assembly-22">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df87">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df87">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df88">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df89">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df89.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df8a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df8a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df8a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df8b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df8a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-22">
-            <physvol name="assembly-22.veto1">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-22.veto2">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-22.veto3">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df8b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-23">
-            <physvol name="vetoLayerFront1">
+            <physvol name="assembly-23.veto1">
                 <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-23.veto2">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-23.veto3">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-24">
+            <physvol name="vetoLayerFront1">
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront2">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront2.position" z="74.0" unit="mm"/>
                 <rotation name="vetoLayerFront2.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront3">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront3.position" z="148.0" unit="mm"/>
                 <rotation name="vetoLayerFront3.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront4">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront4.position" z="222.0" unit="mm"/>
                 <rotation name="vetoLayerFront4.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="327.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoSystemBottom.position" y="-437.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoSystemRight.position" x="-387.0" z="119.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoSystemLeft.position" x="387.0" z="-80.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSystemBack.position" x="-65.0" z="-692.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-23"/>
+                <volumeref ref="assembly-24"/>
                 <position name="vetoSystemFront.position" x="65.0" z="711.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4125,11 +4147,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
                 <position name="VetoSystem.position" y="40.0" z="400.0" unit="mm"/>
             </physvol>
             <materialref ref="G4_AIR"/>

--- a/gdml/IAXO-D1/CompleteVeto4Layers.gdml
+++ b/gdml/IAXO-D1/CompleteVeto4Layers.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3677,12 +3679,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4149,7 +4185,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/IAXO-D1/Default.gdml
+++ b/gdml/IAXO-D1/Default.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3677,12 +3679,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4119,7 +4155,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/IAXO-D1/Default.gdml
+++ b/gdml/IAXO-D1/Default.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3663,6 +3669,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3697,42 +3719,42 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-1500.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-1500.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-1500.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-73266210">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266211">
+            <physvol name="captureLayerVolume-1500.0mm-73266211">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-73266211.position" z="-815.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-73266212.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
+        <assembly name="assembly-6">
+            <physvol name="assembly-6.veto1">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
             </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-800.0mm">
@@ -3751,339 +3773,339 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-207.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="207.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+        <assembly name="assembly-9">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-207.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="207.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerTop1.position" y="-35.0" z="-240.0" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop2">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop2.position" y="59.0" unit="mm"/>
                 <rotation name="vetoLayerTop2.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop3">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop3.position" y="118.0" unit="mm"/>
                 <rotation name="vetoLayerTop3.rotation" y="540.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-9">
-            <physvol name="scintillatorVolume-1500.0mm-73266212">
+        <assembly name="assembly-10">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df66">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-73266213">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df67">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-73266214">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df68">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266214.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-73266215">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-73266215.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266216">
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6a">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-73266216.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-10">
-            <physvol name="assembly-10.veto1">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto2">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto3">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-10.veto4">
-                <volumeref ref="assembly-9"/>
-                <position name="assembly-10.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6a.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-11">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-11.veto1">
                 <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto2">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto3">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto4">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-12">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom1.position" y="20.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom2">
-                <volumeref ref="assembly-10"/>
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom2.position" y="-59.0" unit="mm"/>
                 <rotation name="vetoLayerBottom2.rotation" y="540.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom3">
-                <volumeref ref="assembly-10"/>
+                <volumeref ref="assembly-11"/>
                 <position name="vetoLayerBottom3.position" y="-118.0" unit="mm"/>
                 <rotation name="vetoLayerBottom3.rotation" y="720.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-12">
-            <physvol name="scintillatorVolume-1500.0mm-f1a5df68">
+        <assembly name="assembly-13">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df69">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df69">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6a">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-f1a5df6a">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6a.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-f1a5df6b">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6b.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6c">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6c">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6d">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6c.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-13">
-            <physvol name="assembly-13.veto1">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-13.veto2">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-13.veto3">
-                <volumeref ref="assembly-12"/>
-                <position name="assembly-13.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6d.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-14">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-14.veto1">
                 <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-14.veto2">
+                <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-14.veto3">
+                <volumeref ref="assembly-13"/>
+                <position name="assembly-14.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-15">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight2">
-                <volumeref ref="assembly-13"/>
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight2.position" x="-74.0" unit="mm"/>
                 <rotation name="vetoLayerRight2.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight3">
-                <volumeref ref="assembly-13"/>
+                <volumeref ref="assembly-14"/>
                 <position name="vetoLayerRight3.position" x="-148.0" unit="mm"/>
                 <rotation name="vetoLayerRight3.rotation" x="180.0" z="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-15">
-            <physvol name="scintillatorVolume-1500.0mm-f1a5df6b">
+        <assembly name="assembly-16">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df6c">
                 <volumeref ref="scintillatorVolume-1500.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6c">
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6d">
                 <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-1500.0mm-f1a5df6d">
-                <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6d.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-1500.0mm-f1a5df6e">
                 <volumeref ref="captureLayerVolume-1500.0mm"/>
-                <position name="captureLayerVolume-1500.0mm-f1a5df6e.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6f">
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6f">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df70">
                 <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
-                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6f.position" z="-815.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-16">
-            <physvol name="assembly-16.veto1">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-16.veto2">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-16.veto3">
-                <volumeref ref="assembly-15"/>
-                <position name="assembly-16.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df70.position" z="-815.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-17">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-17.veto1">
                 <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-17.veto2">
+                <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-17.veto3">
+                <volumeref ref="assembly-16"/>
+                <position name="assembly-17.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-18">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft2">
-                <volumeref ref="assembly-16"/>
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft2.position" x="74.0" unit="mm"/>
                 <rotation name="vetoLayerLeft2.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft3">
-                <volumeref ref="assembly-16"/>
+                <volumeref ref="assembly-17"/>
                 <position name="vetoLayerLeft3.position" x="148.0" unit="mm"/>
                 <rotation name="vetoLayerLeft3.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-18">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6e">
+        <assembly name="assembly-19">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6f">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df71">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df72.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-19">
-            <physvol name="assembly-19.veto1">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-19.veto2">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-19.veto3">
-                <volumeref ref="assembly-18"/>
-                <position name="assembly-19.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-20">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-20.veto1">
                 <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-20.veto2">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-20.veto3">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-21">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack1.position" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack2">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack2.position" z="-74.0" unit="mm"/>
                 <rotation name="vetoLayerBack2.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack3">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="vetoLayerBack3.position" z="-148.0" unit="mm"/>
                 <rotation name="vetoLayerBack3.rotation" x="-90.0" y="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df86">
+        <assembly name="assembly-22">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df87">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df87">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df88">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df89">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df89.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df8a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df8a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df8a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df8b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df8a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-22">
-            <physvol name="assembly-22.veto1">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto1.position" x="-212.0" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-22.veto2">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto2.position" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-22.veto3">
-                <volumeref ref="assembly-21"/>
-                <position name="assembly-22.veto3.position" x="212.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df8b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-23">
-            <physvol name="vetoLayerFront1">
+            <physvol name="assembly-23.veto1">
                 <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-23.veto2">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-23.veto3">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-24">
+            <physvol name="vetoLayerFront1">
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront2">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront2.position" z="74.0" unit="mm"/>
                 <rotation name="vetoLayerFront2.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront3">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoLayerFront3.position" z="148.0" unit="mm"/>
                 <rotation name="vetoLayerFront3.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="327.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoSystemBottom.position" y="-437.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoSystemRight.position" x="-387.0" z="119.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoSystemLeft.position" x="387.0" z="-80.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSystemBack.position" x="-65.0" z="-692.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-23"/>
+                <volumeref ref="assembly-24"/>
                 <position name="vetoSystemFront.position" x="65.0" z="711.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4095,11 +4117,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
                 <position name="VetoSystem.position" y="40.0" z="400.0" unit="mm"/>
             </physvol>
             <materialref ref="G4_AIR"/>

--- a/gdml/IAXO-D1/DefaultXenon.gdml
+++ b/gdml/IAXO-D1/DefaultXenon.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3663,6 +3669,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3697,299 +3719,299 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
         </volume>
-        <assembly name="assembly-4">
-            <physvol name="scintillatorVolume-800.0mm-7326620d">
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-800.0mm-7326620e">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-7326620e">
+            <physvol name="scintillatorWrappingSolid-800.0mm-7326620f">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-7326620f">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-7326620f.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266210">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266210.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266210.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266211">
+            <physvol name="captureLayerVolume-800.0mm-73266211">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266212">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266211.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-5">
-            <physvol name="assembly-5.veto1">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto2">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto3">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-5.veto4">
-                <volumeref ref="assembly-4"/>
-                <position name="assembly-5.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266212.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-6">
-            <physvol name="vetoLayerTop1">
+            <physvol name="assembly-6.veto1">
                 <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop1.position" unit="mm"/>
                 <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop2">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop2.position" y="74.0" unit="mm"/>
                 <rotation name="vetoLayerTop2.rotation" y="180.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerTop3">
-                <volumeref ref="assembly-5"/>
+                <volumeref ref="assembly-6"/>
                 <position name="vetoLayerTop3.position" y="148.0" unit="mm"/>
                 <rotation name="vetoLayerTop3.rotation" y="180.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-7">
-            <physvol name="scintillatorVolume-800.0mm-73266210">
+        <assembly name="assembly-8">
+            <physvol name="scintillatorVolume-800.0mm-73266211">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-73266211">
+            <physvol name="scintillatorWrappingSolid-800.0mm-73266212">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-73266212">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266212.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-73266213">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-73266213.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-73266213.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-73266214">
+            <physvol name="captureLayerVolume-800.0mm-73266214">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-73266214.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-73266215">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-73266214.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-8">
-            <physvol name="assembly-8.veto1">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto2">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto3">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-8.veto4">
-                <volumeref ref="assembly-7"/>
-                <position name="assembly-8.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-73266215.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-9">
-            <physvol name="vetoLayerBottom1">
+            <physvol name="assembly-9.veto1">
                 <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto2">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto3">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-9.veto4">
+                <volumeref ref="assembly-8"/>
+                <position name="assembly-9.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-10">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom1.position" y="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBottom1.rotation" y="360.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom2">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom2.position" y="-54.0" unit="mm"/>
                 <rotation name="vetoLayerBottom2.rotation" y="540.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBottom3">
-                <volumeref ref="assembly-8"/>
+                <volumeref ref="assembly-9"/>
                 <position name="vetoLayerBottom3.position" y="-108.0" unit="mm"/>
                 <rotation name="vetoLayerBottom3.rotation" y="720.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-10">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df66">
+        <assembly name="assembly-11">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df67">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df67">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df68">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df68">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df68.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df69">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6a">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6a">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6a.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-11">
-            <physvol name="assembly-11.veto1">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto2">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto3">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-11.veto4">
-                <volumeref ref="assembly-10"/>
-                <position name="assembly-11.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6b.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-12">
-            <physvol name="vetoLayerRight1">
+            <physvol name="assembly-12.veto1">
                 <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto2">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto3">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-12.veto4">
+                <volumeref ref="assembly-11"/>
+                <position name="assembly-12.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-13">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
                 <rotation name="vetoLayerRight1.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight2">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight2.position" x="-74.0" unit="mm"/>
                 <rotation name="vetoLayerRight2.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerRight3">
-                <volumeref ref="assembly-11"/>
+                <volumeref ref="assembly-12"/>
                 <position name="vetoLayerRight3.position" x="-148.0" unit="mm"/>
                 <rotation name="vetoLayerRight3.rotation" x="-90.0" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-13">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df69">
+        <assembly name="assembly-14">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6a">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6a">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6b">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6b">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6b.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6c">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6c.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6d">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6d">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6d.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6d.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-14">
-            <physvol name="assembly-14.veto1">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto2">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto3">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-14.veto4">
-                <volumeref ref="assembly-13"/>
-                <position name="assembly-14.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6e.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-15">
-            <physvol name="vetoLayerLeft1">
+            <physvol name="assembly-15.veto1">
                 <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto2">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto3">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto4">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-16">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft1.position" unit="mm"/>
                 <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft2">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft2.position" x="74.0" unit="mm"/>
                 <rotation name="vetoLayerLeft2.rotation" z="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerLeft3">
-                <volumeref ref="assembly-14"/>
+                <volumeref ref="assembly-15"/>
                 <position name="vetoLayerLeft3.position" x="148.0" unit="mm"/>
                 <rotation name="vetoLayerLeft3.rotation" z="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-16">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6c">
+        <assembly name="assembly-17">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6d">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6d">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6e">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df6e">
-                <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6e.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-800.0mm-f1a5df6f">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df70">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df71">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df70.position" z="-465.0" unit="mm"/>
-            </physvol>
-        </assembly>
-        <assembly name="assembly-17">
-            <physvol name="assembly-17.veto1">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto1.position" x="-310.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto2">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto2.position" x="-103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto3">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto3.position" x="103.5" unit="mm"/>
-            </physvol>
-            <physvol name="assembly-17.veto4">
-                <volumeref ref="assembly-16"/>
-                <position name="assembly-17.veto4.position" x="310.5" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df71.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <assembly name="assembly-18">
-            <physvol name="vetoLayerBack1">
+            <physvol name="assembly-18.veto1">
                 <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto2">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto3">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto4">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-19">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack1.position" y="80.0" z="-0.0" unit="mm"/>
                 <rotation name="vetoLayerBack1.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack2">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack2.position" y="80.0" z="-74.0" unit="mm"/>
                 <rotation name="vetoLayerBack2.rotation" x="-90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerBack3">
-                <volumeref ref="assembly-17"/>
+                <volumeref ref="assembly-18"/>
                 <position name="vetoLayerBack3.position" y="80.0" z="-148.0" unit="mm"/>
                 <rotation name="vetoLayerBack3.rotation" x="-90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-19">
-            <physvol name="scintillatorVolume-800.0mm-f1a5df6f">
+        <assembly name="assembly-20">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df85">
                 <volumeref ref="scintillatorVolume-800.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df70">
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df86">
                 <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df71">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df87">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df71.position" y="26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="captureLayerVolume-800.0mm-f1a5df72">
+            <physvol name="captureLayerVolume-800.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-800.0mm"/>
-                <position name="captureLayerVolume-800.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df73">
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df89">
                 <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
-                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df73.position" z="-465.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df89.position" z="-465.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="scintillatorVolume-300.0mm">
@@ -4008,85 +4030,85 @@
             <materialref ref="G4_LUCITE"/>
             <solidref ref="scintillatorLightGuideSolid-300.0mm"/>
         </volume>
-        <assembly name="assembly-20">
-            <physvol name="scintillatorVolume-300.0mm-f1a5df85">
+        <assembly name="assembly-21">
+            <physvol name="scintillatorVolume-300.0mm-f1a5df86">
                 <volumeref ref="scintillatorVolume-300.0mm"/>
             </physvol>
-            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df86">
+            <physvol name="scintillatorWrappingSolid-300.0mm-f1a5df87">
                 <volumeref ref="scintillatorWrappingSolid-300.0mm"/>
-            </physvol>
-            <physvol name="captureLayerVolume-300.0mm-f1a5df87">
-                <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df87.position" y="26.5" unit="mm"/>
             </physvol>
             <physvol name="captureLayerVolume-300.0mm-f1a5df88">
                 <volumeref ref="captureLayerVolume-300.0mm"/>
-                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="-26.5" unit="mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df88.position" y="26.5" unit="mm"/>
             </physvol>
-            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df89">
+            <physvol name="captureLayerVolume-300.0mm-f1a5df89">
+                <volumeref ref="captureLayerVolume-300.0mm"/>
+                <position name="captureLayerVolume-300.0mm-f1a5df89.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-300.0mm-f1a5df8a">
                 <volumeref ref="scintillatorLightGuideVolume-300.0mm"/>
-                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df89.position" z="-215.0" unit="mm"/>
+                <position name="scintillatorLightGuideVolume-300.0mm-f1a5df8a.position" z="-215.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-21">
+        <assembly name="assembly-22">
             <physvol name="veto0">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto0.position" x="-207.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmall1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmall1.position" z="-250.0" unit="mm"/>
             </physvol>
             <physvol name="vetoSmallRotated1">
-                <volumeref ref="assembly-20"/>
+                <volumeref ref="assembly-21"/>
                 <position name="vetoSmallRotated1.position" z="250.0" unit="mm"/>
                 <rotation name="vetoSmallRotated1.rotation" x="180.0" unit="deg"/>
             </physvol>
             <physvol name="veto2">
-                <volumeref ref="assembly-19"/>
+                <volumeref ref="assembly-20"/>
                 <position name="veto2.position" x="207.0" unit="mm"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-22">
+        <assembly name="assembly-23">
             <physvol name="vetoLayerFront1">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront1.position" unit="mm"/>
                 <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront2">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront2.position" z="74.0" unit="mm"/>
                 <rotation name="vetoLayerFront2.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
             <physvol name="vetoLayerFront3">
-                <volumeref ref="assembly-21"/>
+                <volumeref ref="assembly-22"/>
                 <position name="vetoLayerFront3.position" z="148.0" unit="mm"/>
                 <rotation name="vetoLayerFront3.rotation" x="-90.0" y="90.0" unit="deg"/>
             </physvol>
         </assembly>
-        <assembly name="assembly-3">
+        <assembly name="assembly-4">
             <physvol name="vetoSystemTop">
-                <volumeref ref="assembly-6"/>
+                <volumeref ref="assembly-7"/>
                 <position name="vetoSystemTop.position" y="357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBottom">
-                <volumeref ref="assembly-9"/>
+                <volumeref ref="assembly-10"/>
                 <position name="vetoSystemBottom.position" y="-357.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemRight">
-                <volumeref ref="assembly-12"/>
+                <volumeref ref="assembly-13"/>
                 <position name="vetoSystemRight.position" x="-467.0" z="-10.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemLeft">
-                <volumeref ref="assembly-15"/>
+                <volumeref ref="assembly-16"/>
                 <position name="vetoSystemLeft.position" x="467.0" z="19.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemBack">
-                <volumeref ref="assembly-18"/>
+                <volumeref ref="assembly-19"/>
                 <position name="vetoSystemBack.position" y="80.0" z="-422.5" unit="mm"/>
             </physvol>
             <physvol name="vetoSystemFront">
-                <volumeref ref="assembly-22"/>
+                <volumeref ref="assembly-23"/>
                 <position name="vetoSystemFront.position" z="461.5" unit="mm"/>
             </physvol>
         </assembly>
@@ -4098,11 +4120,15 @@
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
             </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+            </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>
             </physvol>
             <physvol name="VetoSystem">
-                <volumeref ref="assembly-3"/>
+                <volumeref ref="assembly-4"/>
             </physvol>
             <materialref ref="G4_AIR"/>
             <solidref ref="worldBox"/>

--- a/gdml/IAXO-D1/DefaultXenon.gdml
+++ b/gdml/IAXO-D1/DefaultXenon.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3677,12 +3679,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -4122,7 +4158,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/IAXO-D1/NoVetos.gdml
+++ b/gdml/IAXO-D1/NoVetos.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3636,12 +3638,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">
@@ -3672,7 +3708,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/IAXO-D1/NoVetos.gdml
+++ b/gdml/IAXO-D1/NoVetos.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="copperBoxOutterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -3622,6 +3628,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="copperBoxVolume">
             <materialref ref="G4_Cu"/>
             <solidref ref="copperBoxSolid"/>
@@ -3647,6 +3669,10 @@
             <physvol name="DetectorPipe">
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
+            </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/IAXO-D1/ShieldingLayers.gdml
+++ b/gdml/IAXO-D1/ShieldingLayers.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="shieldingLayerBox1" x="220.0" y="220.0" z="360.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerHole1" x="200.0" y="200.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="shieldingLayerBoxWithHole1">
@@ -3755,6 +3761,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="shieldingVolumeLayer1">
             <materialref ref="G4_Pb"/>
             <solidref ref="shieldingLayerBoxWithHole1"/>
@@ -3932,6 +3954,10 @@
             <physvol name="DetectorPipe">
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
+            </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/IAXO-D1/ShieldingLayers.gdml
+++ b/gdml/IAXO-D1/ShieldingLayers.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerBox1" x="220.0" y="220.0" z="360.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerHole1" x="200.0" y="200.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="shieldingLayerBoxWithHole1">
@@ -3769,12 +3771,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="shieldingVolumeLayer1">
@@ -3957,7 +3993,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/IAXO-D1/ShieldingLayersNoCopperBox.gdml
+++ b/gdml/IAXO-D1/ShieldingLayersNoCopperBox.gdml
@@ -3500,12 +3500,14 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
-        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
         <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatcableSolid" x="1.0" y="70.0" z="150.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerBox1" x="220.0" y="220.0" z="360.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerHole1" x="200.0" y="200.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="shieldingLayerBoxWithHole1">
@@ -3769,12 +3771,46 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatcableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatcableSolid"/>
+        </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsBox">
-                <volumeref ref="electronicsBoxVolume"/>
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
             </physvol>
-            <physvol name="electronicsBoxFilling">
-                <volumeref ref="electronicsBoxFillingVolume"/>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable1">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable2">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable3">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatcable4">
+                <volumeref ref="flatcableVolume"/>
+                <position name="flatcable4.position" x="15.0" z="-125.0" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="shieldingVolumeLayer1">
@@ -3953,7 +3989,7 @@
             </physvol>
             <physvol name="ElectronicsBox">
                 <volumeref ref="electronicsBox"/>
-                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/gdml/IAXO-D1/ShieldingLayersNoCopperBox.gdml
+++ b/gdml/IAXO-D1/ShieldingLayersNoCopperBox.gdml
@@ -3500,6 +3500,12 @@
             <first ref="detectorPipeNotEmpty"/>
             <second ref="detectorPipeInside"/>
         </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="40.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="30.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
         <box lunit="mm" aunit="rad" name="shieldingLayerBox1" x="220.0" y="220.0" z="360.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerHole1" x="200.0" y="200.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="shieldingLayerBoxWithHole1">
@@ -3755,6 +3761,22 @@
                 <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
             </physvol>
         </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsBox">
+                <volumeref ref="electronicsBoxVolume"/>
+            </physvol>
+            <physvol name="electronicsBoxFilling">
+                <volumeref ref="electronicsBoxFillingVolume"/>
+            </physvol>
+        </assembly>
         <volume name="shieldingVolumeLayer1">
             <materialref ref="G4_Pb"/>
             <solidref ref="shieldingLayerBoxWithHole1"/>
@@ -3928,6 +3950,10 @@
             <physvol name="DetectorPipe">
                 <volumeref ref="detectorPipe"/>
                 <position name="DetectorPipe.position" z="27.0" unit="mm"/>
+            </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="67.0" z="245.0" unit="mm"/>
             </physvol>
             <physvol name="Shielding">
                 <volumeref ref="shielding"/>

--- a/generator/src/main/kotlin/BabyIAXO/Electronics.kt
+++ b/generator/src/main/kotlin/BabyIAXO/Electronics.kt
@@ -10,12 +10,22 @@ open class Electronics : Geometry() {
 
         // Box : Dimensions 
         const val electronicsBoxLongSideZ: Double = 200.0
-        const val electronicsBoxShortSideX: Double = 40.0
+        const val electronicsBoxShortSideX: Double = 41.0
         const val electronicsBoxShortSideY: Double = 90.0
         const val electronicsBoxThickness: Double = 5.0
 
+        //Card Dimensions
+        const val cardLongSizeZ: Double = 100.0
+        const val cardShortSideX: Double = 2.5
+        const val cardShortSideY: Double = 70.0
+
+        //flat cable Dimensions
+        const val flatcableLongSideZ: Double = 150.0
+        const val flatcableShortSideX: Double = 1.0
+        const val flatcableShortSideY: Double = 70.0
+
         // Distance 
-        const val DetectorToElectronicsDistanceZ: Double = 245.0
+        const val DetectorToElectronicsDistanceZ: Double = 235.0
         const val PipeToElectronicsOffSetX: Double = 5.0
         const val PipeToElectronicsDistanceX: Double = 82.0 - (electronicsBoxShortSideX / 2) + PipeToElectronicsOffSetX
 
@@ -24,6 +34,7 @@ open class Electronics : Geometry() {
     override fun generate (gdml : Gdml): GdmlRef<GdmlAssembly> {
         val electronicsBoxVolume: GdmlRef<GdmlAssembly> by lazy {
 
+            //Box 
             val electronicsBoxOutSolid = gdml.solids.box(
                 electronicsBoxShortSideX,
                 electronicsBoxShortSideY,
@@ -42,19 +53,63 @@ open class Electronics : Geometry() {
                 electronicsBoxOutSolid, electronicsBoxInSolid,
                 "electronicsBoxSolid")
 
+            //Card
+            val electronicsCardSolid = gdml.solids.box(
+                cardShortSideX,
+                cardShortSideY,
+                cardLongSizeZ,
+                "electronicsCardSolid")
+
+            //Flat cable
+            val flatcableSolid = gdml.solids.box(
+                flatcableShortSideX,
+                flatcableShortSideY,
+                flatcableLongSideZ,
+                "flatcableSolid")
+
             val electronicsBoxVolume = 
             gdml.structure.volume(Materials.Copper.ref,electronicsBoxSolid,"electronicsBoxVolume")
 
             val electronicsBoxFillingVolume =
             gdml.structure.volume(Materials.Vacuum.ref,electronicsBoxInSolid,"electronicsBoxFillingVolume")
 
+            val electronicsCardVolume = 
+            gdml.structure.volume(Materials.Copper.ref,electronicsCardSolid,"electronicsCardVolume")
+
+            val flatcableVolume =
+            gdml.structure.volume(Materials.Copper.ref,flatcableSolid,"flatcableVolume")
+
             return@lazy gdml.structure.assembly {
                 name = "electronicsBox"
-                physVolume(electronicsBoxVolume){
-                    name = "electronicsBox"
+                //physVolume(electronicsBoxVolume, name = "electronicsBox")
+
+                //physVolume(electronicsBoxFillingVolume, name = "electronicsBoxFilling")
+
+
+                physVolume(electronicsCardVolume, name = "electronicsCard1"){
+                    position(x = - 15.0 ) { unit = LUnit.MM }
                 }
-                physVolume(electronicsBoxFillingVolume){
-                    name = "electronicsBoxFilling"
+                physVolume(electronicsCardVolume, name = "electronicsCard2"){
+                    position(x = - 5.0 ) { unit = LUnit.MM }
+                }
+                physVolume(electronicsCardVolume, name = "electronicsCard3"){
+                    position(x = 5.0 ) { unit = LUnit.MM }
+                }
+                physVolume(electronicsCardVolume, name = "electronicsCard4"){
+                    position(x = 15.0 ) { unit = LUnit.MM }
+                }
+
+                physVolume(flatcableVolume, name = "flatcable1"){
+                    position(x = - 15.0, z = - cardLongSizeZ / 2 - flatcableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                physVolume(flatcableVolume, name = "flatcable2"){
+                    position(x = - 5.0, z = - cardLongSizeZ / 2 - flatcableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                physVolume(flatcableVolume, name = "flatcable3"){
+                    position(x = 5.0, z = - cardLongSizeZ / 2 - flatcableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                physVolume(flatcableVolume, name = "flatcable4"){
+                    position(x = 15.0, z = - cardLongSizeZ / 2 - flatcableLongSideZ / 2) { unit = LUnit.MM }
                 }
             }
         }

--- a/generator/src/main/kotlin/BabyIAXO/Electronics.kt
+++ b/generator/src/main/kotlin/BabyIAXO/Electronics.kt
@@ -1,0 +1,63 @@
+package BabyIAXO
+
+import Geometry
+
+import space.kscience.gdml.*
+
+open class Electronics : Geometry() {
+
+    companion object Parameters {
+
+        // Box : Dimensions 
+        const val electronicsBoxLongSideZ: Double = 200.0
+        const val electronicsBoxShortSideX: Double = 40.0
+        const val electronicsBoxShortSideY: Double = 90.0
+        const val electronicsBoxThickness: Double = 5.0
+
+        // Distance 
+        const val DetectorToElectronicsDistanceZ: Double = 245.0
+        const val PipeToElectronicsDistanceX: Double = 82.0 - electronicsBoxShortSideX / 2
+
+    }
+
+    override fun generate (gdml : Gdml): GdmlRef<GdmlAssembly> {
+        val electronicsBoxVolume: GdmlRef<GdmlAssembly> by lazy {
+
+            val electronicsBoxOutSolid = gdml.solids.box(
+                electronicsBoxShortSideX,
+                electronicsBoxShortSideY,
+                electronicsBoxLongSideZ,
+                "electronicsBoxOutSolid"
+            )
+
+            val electronicsBoxInSolid = gdml.solids.box(
+                electronicsBoxShortSideX - electronicsBoxThickness*2,
+                electronicsBoxShortSideY - electronicsBoxThickness*2,
+                electronicsBoxLongSideZ - electronicsBoxThickness*2,
+                "electronicsBoxInSolid"
+            )
+
+            val electronicsBoxSolid = gdml.solids.subtraction(
+                electronicsBoxOutSolid, electronicsBoxInSolid,
+                "electronicsBoxSolid")
+
+            val electronicsBoxVolume = 
+            gdml.structure.volume(Materials.Copper.ref,electronicsBoxSolid,"electronicsBoxVolume")
+
+            val electronicsBoxFillingVolume =
+            gdml.structure.volume(Materials.Vacuum.ref,electronicsBoxInSolid,"electronicsBoxFillingVolume")
+
+            return@lazy gdml.structure.assembly {
+                name = "electronicsBox"
+                physVolume(electronicsBoxVolume){
+                    name = "electronicsBox"
+                }
+                physVolume(electronicsBoxFillingVolume){
+                    name = "electronicsBoxFilling"
+                }
+            }
+        }
+        
+        return electronicsBoxVolume
+    }
+}

--- a/generator/src/main/kotlin/BabyIAXO/Electronics.kt
+++ b/generator/src/main/kotlin/BabyIAXO/Electronics.kt
@@ -17,7 +17,7 @@ open class Electronics : Geometry() {
         // Distance 
         const val DetectorToElectronicsDistanceZ: Double = 245.0
         const val PipeToElectronicsOffSetX: Double = 5.0
-        const val PipeToElectronicsDistanceX: Double = 82.0 - (electronicsBoxShortSideX / 2) + PipeToElectronicsOffSetS
+        const val PipeToElectronicsDistanceX: Double = 82.0 - (electronicsBoxShortSideX / 2) + PipeToElectronicsOffSetX
 
     }
 

--- a/generator/src/main/kotlin/BabyIAXO/Electronics.kt
+++ b/generator/src/main/kotlin/BabyIAXO/Electronics.kt
@@ -16,7 +16,8 @@ open class Electronics : Geometry() {
 
         // Distance 
         const val DetectorToElectronicsDistanceZ: Double = 245.0
-        const val PipeToElectronicsDistanceX: Double = 82.0 - electronicsBoxShortSideX / 2
+        const val PipeToElectronicsOffSetX: Double = 5.0
+        const val PipeToElectronicsDistanceX: Double = 82.0 - (electronicsBoxShortSideX / 2) + PipeToElectronicsOffSetS
 
     }
 

--- a/generator/src/main/kotlin/BabyIAXO/Main.kt
+++ b/generator/src/main/kotlin/BabyIAXO/Main.kt
@@ -17,6 +17,7 @@ fun completeGeometry(
 
         val chamberVolume = Chamber(useXenon = useXenon).generate(this)
         val detectorPipeVolume = DetectorPipe().generate(this)
+        val electronicsBoxVolume = Electronics().generate(this) 
         val shieldingVolume = Shielding().generate(this)
         val vetoSystemVolume = vetoSystem.generate(this)
 
@@ -27,6 +28,12 @@ fun completeGeometry(
                 physVolume(chamberVolume, name = "Chamber")
                 physVolume(detectorPipeVolume, name = "DetectorPipe") {
                     position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name  = "ElectronicsBox"){
+                    position(x = Electronics.PipeToElectronicsDistanceX,
+                    z = Electronics.DetectorToElectronicsDistanceZ) {
                         unit = LUnit.MM
                     }
                 }
@@ -50,6 +57,7 @@ val geometries = mapOf(
 
         val chamberVolume = Chamber().generate(this)
         val detectorPipeVolume = DetectorPipe().generate(this)
+        val electronicsBoxVolume = Electronics().generate(this)
         val shieldingVolume = Shielding().generate(this)
 
         structure {
@@ -59,6 +67,12 @@ val geometries = mapOf(
                 physVolume(chamberVolume, name = "Chamber")
                 physVolume(detectorPipeVolume, name = "DetectorPipe") {
                     position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name  = "ElectronicsBox"){
+                    position(x = Electronics.PipeToElectronicsDistanceX,
+                    z = Electronics.DetectorToElectronicsDistanceZ) {
                         unit = LUnit.MM
                     }
                 }
@@ -72,6 +86,7 @@ val geometries = mapOf(
 
         val chamberVolume = Chamber().generate(this)
         val detectorPipeVolume = DetectorPipe().generate(this)
+        val electronicsBoxVolume = Electronics().generate(this)
         val shieldingVolume = Shielding(layers = true).generate(this)
 
         structure {
@@ -81,6 +96,12 @@ val geometries = mapOf(
                 physVolume(chamberVolume, name = "Chamber")
                 physVolume(detectorPipeVolume, name = "DetectorPipe") {
                     position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name  = "ElectronicsBox"){
+                    position(x = Electronics.PipeToElectronicsDistanceX,
+                    z = Electronics.DetectorToElectronicsDistanceZ) {
                         unit = LUnit.MM
                     }
                 }
@@ -94,6 +115,7 @@ val geometries = mapOf(
 
         val chamberVolume = Chamber().generate(this)
         val detectorPipeVolume = DetectorPipe().generate(this)
+        val electronicsBoxVolume = Electronics().generate(this)
         val shieldingVolume = Shielding(layers = true, copperBox = false).generate(this)
 
         structure {
@@ -103,6 +125,12 @@ val geometries = mapOf(
                 physVolume(chamberVolume, name = "Chamber")
                 physVolume(detectorPipeVolume, name = "DetectorPipe") {
                     position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name  = "ElectronicsBox"){
+                    position(x = Electronics.PipeToElectronicsDistanceX,
+                    z = Electronics.DetectorToElectronicsDistanceZ) {
                         unit = LUnit.MM
                     }
                 }
@@ -116,6 +144,7 @@ val geometries = mapOf(
 
         val chamberVolume = Chamber().generate(this)
         val detectorPipeVolume = DetectorPipe().generate(this)
+        val electronicsBoxVolume = Electronics().generate(this)
 
         structure {
             val worldBox = solids.box(worldSizeX, worldSizeY, worldSizeZ, "worldBox")
@@ -124,6 +153,12 @@ val geometries = mapOf(
                 physVolume(chamberVolume, name = "Chamber")
                 physVolume(detectorPipeVolume, name = "DetectorPipe") {
                     position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name  = "ElectronicsBox"){
+                    position(x = Electronics.PipeToElectronicsDistanceX,
+                    z = Electronics.DetectorToElectronicsDistanceZ) {
                         unit = LUnit.MM
                     }
                 }
@@ -207,6 +242,7 @@ val geometries = mapOf(
 
         val chamberVolume = Chamber().generate(this)
         val detectorPipeVolume = DetectorPipe().generate(this)
+        val electronicsBoxVolume = Electronics().generate(this)
         val shieldingVolume = Shielding().generate(this)
         val vetoSystemVolume = VetoSystem().generate(this)
         val telescopePipe = TelescopePipe().generate(this)
@@ -218,6 +254,12 @@ val geometries = mapOf(
                 physVolume(chamberVolume, name = "Chamber")
                 physVolume(detectorPipeVolume, name = "DetectorPipe") {
                     position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name  = "ElectronicsBox"){
+                    position(x = Electronics.PipeToElectronicsDistanceX,
+                    z = Electronics.DetectorToElectronicsDistanceZ) {
                         unit = LUnit.MM
                     }
                 }

--- a/generator/src/main/kotlin/IAXO-D1/Electronics.kt
+++ b/generator/src/main/kotlin/IAXO-D1/Electronics.kt
@@ -10,12 +10,22 @@ open class Electronics : Geometry() {
 
         // Box : Dimensions 
         const val electronicsBoxLongSideZ: Double = 200.0
-        const val electronicsBoxShortSideX: Double = 40.0
+        const val electronicsBoxShortSideX: Double = 41.0
         const val electronicsBoxShortSideY: Double = 90.0
         const val electronicsBoxThickness: Double = 5.0
 
+        //Card Dimensions
+        const val cardLongSizeZ: Double = 100.0
+        const val cardShortSideX: Double = 2.5
+        const val cardShortSideY: Double = 70.0
+
+        //flat cable Dimensions
+        const val flatcableLongSideZ: Double = 150.0
+        const val flatcableShortSideX: Double = 1.0
+        const val flatcableShortSideY: Double = 70.0
+
         // Distance 
-        const val DetectorToElectronicsDistanceZ: Double = 245.0
+        const val DetectorToElectronicsDistanceZ: Double = 235.0
         const val PipeToElectronicsOffSetX: Double = 5.0
         const val PipeToElectronicsDistanceX: Double = 82.0 - (electronicsBoxShortSideX / 2) + PipeToElectronicsOffSetX
 
@@ -42,19 +52,63 @@ open class Electronics : Geometry() {
                 electronicsBoxOutSolid, electronicsBoxInSolid,
                 "electronicsBoxSolid")
 
+            //Card
+            val electronicsCardSolid = gdml.solids.box(
+                cardShortSideX,
+                cardShortSideY,
+                cardLongSizeZ,
+                "electronicsCardSolid")
+
+            //Flat cable
+            val flatcableSolid = gdml.solids.box(
+                flatcableShortSideX,
+                flatcableShortSideY,
+                flatcableLongSideZ,
+                "flatcableSolid")
+
             val electronicsBoxVolume = 
             gdml.structure.volume(Materials.Copper.ref,electronicsBoxSolid,"electronicsBoxVolume")
 
             val electronicsBoxFillingVolume =
             gdml.structure.volume(Materials.Vacuum.ref,electronicsBoxInSolid,"electronicsBoxFillingVolume")
 
+             val electronicsCardVolume = 
+            gdml.structure.volume(Materials.Copper.ref,electronicsCardSolid,"electronicsCardVolume")
+
+            val flatcableVolume =
+            gdml.structure.volume(Materials.Copper.ref,flatcableSolid,"flatcableVolume")
+
             return@lazy gdml.structure.assembly {
                 name = "electronicsBox"
-                physVolume(electronicsBoxVolume){
-                    name = "electronicsBox"
+                //physVolume(electronicsBoxVolume, name = "electronicsBox")
+
+                //physVolume(electronicsBoxFillingVolume, name = "electronicsBoxFilling")
+
+
+                physVolume(electronicsCardVolume, name = "electronicsCard1"){
+                    position(x = - 15.0 ) { unit = LUnit.MM }
                 }
-                physVolume(electronicsBoxFillingVolume){
-                    name = "electronicsBoxFilling"
+                physVolume(electronicsCardVolume, name = "electronicsCard2"){
+                    position(x = - 5.0 ) { unit = LUnit.MM }
+                }
+                physVolume(electronicsCardVolume, name = "electronicsCard3"){
+                    position(x = 5.0 ) { unit = LUnit.MM }
+                }
+                physVolume(electronicsCardVolume, name = "electronicsCard4"){
+                    position(x = 15.0 ) { unit = LUnit.MM }
+                }
+
+                physVolume(flatcableVolume, name = "flatcable1"){
+                    position(x = - 15.0, z = - cardLongSizeZ / 2 - flatcableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                physVolume(flatcableVolume, name = "flatcable2"){
+                    position(x = - 5.0, z = - cardLongSizeZ / 2 - flatcableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                physVolume(flatcableVolume, name = "flatcable3"){
+                    position(x = 5.0, z = - cardLongSizeZ / 2 - flatcableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                physVolume(flatcableVolume, name = "flatcable4"){
+                    position(x = 15.0, z = - cardLongSizeZ / 2 - flatcableLongSideZ / 2) { unit = LUnit.MM }
                 }
             }
         }

--- a/generator/src/main/kotlin/IAXO-D1/Electronics.kt
+++ b/generator/src/main/kotlin/IAXO-D1/Electronics.kt
@@ -1,0 +1,64 @@
+package `IAXO-D1`
+
+import Geometry
+
+import space.kscience.gdml.*
+
+open class Electronics : Geometry() {
+
+    companion object Parameters {
+
+        // Box : Dimensions 
+        const val electronicsBoxLongSideZ: Double = 200.0
+        const val electronicsBoxShortSideX: Double = 40.0
+        const val electronicsBoxShortSideY: Double = 90.0
+        const val electronicsBoxThickness: Double = 5.0
+
+        // Distance 
+        const val DetectorToElectronicsDistanceZ: Double = 245.0
+        const val PipeToElectronicsOffSetX: Double = 5.0
+        const val PipeToElectronicsDistanceX: Double = 82.0 - (electronicsBoxShortSideX / 2) + PipeToElectronicsOffSetX
+
+    }
+
+    override fun generate (gdml : Gdml): GdmlRef<GdmlAssembly> {
+        val electronicsBoxVolume: GdmlRef<GdmlAssembly> by lazy {
+
+            val electronicsBoxOutSolid = gdml.solids.box(
+                electronicsBoxShortSideX,
+                electronicsBoxShortSideY,
+                electronicsBoxLongSideZ,
+                "electronicsBoxOutSolid"
+            )
+
+            val electronicsBoxInSolid = gdml.solids.box(
+                electronicsBoxShortSideX - electronicsBoxThickness*2,
+                electronicsBoxShortSideY - electronicsBoxThickness*2,
+                electronicsBoxLongSideZ - electronicsBoxThickness*2,
+                "electronicsBoxInSolid"
+            )
+
+            val electronicsBoxSolid = gdml.solids.subtraction(
+                electronicsBoxOutSolid, electronicsBoxInSolid,
+                "electronicsBoxSolid")
+
+            val electronicsBoxVolume = 
+            gdml.structure.volume(Materials.Copper.ref,electronicsBoxSolid,"electronicsBoxVolume")
+
+            val electronicsBoxFillingVolume =
+            gdml.structure.volume(Materials.Vacuum.ref,electronicsBoxInSolid,"electronicsBoxFillingVolume")
+
+            return@lazy gdml.structure.assembly {
+                name = "electronicsBox"
+                physVolume(electronicsBoxVolume){
+                    name = "electronicsBox"
+                }
+                physVolume(electronicsBoxFillingVolume){
+                    name = "electronicsBoxFilling"
+                }
+            }
+        }
+        
+        return electronicsBoxVolume
+    }
+}

--- a/generator/src/main/kotlin/IAXO-D1/Main.kt
+++ b/generator/src/main/kotlin/IAXO-D1/Main.kt
@@ -17,6 +17,7 @@ fun completeGeometry(
 
         val chamberVolume = Chamber().generate(this)
         val detectorPipeVolume = DetectorPipe().generate(this)
+        val electronicsBoxVolume = Electronics().generate(this) 
         val shieldingVolume = Shielding().generate(this)
         val vetoSystemVolume = vetoSystem.generate(this)
 
@@ -27,6 +28,12 @@ fun completeGeometry(
                 physVolume(chamberVolume, name = "Chamber")
                 physVolume(detectorPipeVolume, name = "DetectorPipe") {
                     position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name  = "ElectronicsBox"){
+                    position(x = Electronics.PipeToElectronicsDistanceX,
+                    z = Electronics.DetectorToElectronicsDistanceZ) {
                         unit = LUnit.MM
                     }
                 }
@@ -57,6 +64,7 @@ val geometries = mapOf(
 
         val chamberVolume = Chamber().generate(this)
         val detectorPipeVolume = DetectorPipe().generate(this)
+        val  electronicsBoxVolume = Electronics().generate(this)
         val shieldingVolume = Shielding(layers = true).generate(this)
 
         structure {
@@ -66,6 +74,12 @@ val geometries = mapOf(
                 physVolume(chamberVolume, name = "Chamber")
                 physVolume(detectorPipeVolume, name = "DetectorPipe") {
                     position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name  = "ElectronicsBox"){
+                    position(x = Electronics.PipeToElectronicsDistanceX,
+                    z = Electronics.DetectorToElectronicsDistanceZ) {
                         unit = LUnit.MM
                     }
                 }
@@ -79,6 +93,7 @@ val geometries = mapOf(
 
         val chamberVolume = Chamber().generate(this)
         val detectorPipeVolume = DetectorPipe().generate(this)
+        val electronicsBoxVolume = Electronics().generate(this)
         val shieldingVolume = Shielding(layers = true, copperBox = false).generate(this)
 
         structure {
@@ -88,6 +103,12 @@ val geometries = mapOf(
                 physVolume(chamberVolume, name = "Chamber")
                 physVolume(detectorPipeVolume, name = "DetectorPipe") {
                     position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name  = "ElectronicsBox"){
+                    position(x = Electronics.PipeToElectronicsDistanceX,
+                    z = Electronics.DetectorToElectronicsDistanceZ) {
                         unit = LUnit.MM
                     }
                 }
@@ -101,6 +122,7 @@ val geometries = mapOf(
 
         val chamberVolume = Chamber().generate(this)
         val detectorPipeVolume = DetectorPipe().generate(this)
+        val electronicsBoxVolume = Electronics().generate(this)
         val shieldingVolume = Shielding().generate(this)
 
         structure {
@@ -110,6 +132,12 @@ val geometries = mapOf(
                 physVolume(chamberVolume, name = "Chamber")
                 physVolume(detectorPipeVolume, name = "DetectorPipe") {
                     position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name  = "ElectronicsBox"){
+                    position(x = Electronics.PipeToElectronicsDistanceX,
+                    z = Electronics.DetectorToElectronicsDistanceZ) {
                         unit = LUnit.MM
                     }
                 }
@@ -123,6 +151,7 @@ val geometries = mapOf(
 
         val chamberVolume = Chamber().generate(this)
         val detectorPipeVolume = DetectorPipe().generate(this)
+        val electronicsBoxVolume = Electronics().generate(this)
 
         structure {
             val worldBox = solids.box(worldSizeX, worldSizeY, worldSizeZ, "worldBox")
@@ -131,6 +160,12 @@ val geometries = mapOf(
                 physVolume(chamberVolume, name = "Chamber")
                 physVolume(detectorPipeVolume, name = "DetectorPipe") {
                     position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name  = "ElectronicsBox"){
+                    position(x = Electronics.PipeToElectronicsDistanceX,
+                    z = Electronics.DetectorToElectronicsDistanceZ) {
                         unit = LUnit.MM
                     }
                 }


### PR DESCRIPTION

Update the geometry and add the radiopure electronics to perform the intrinsic contamination simulations of the electronics. 
The proposed changes are based on this updated model with respect to the AGET chip:
![electronics](https://github.com/iaxo/iaxo-geometry/assets/106647320/a5ee4133-d996-4016-9815-32a5c63f6833)
It consists of 4 cards equidistant 3 cm, 245 mm from the detector and 82 mm from the axis.

As a first approach, I have modeled the electronics as a copper box of 5 mm of thickness, filled with vacuum and dimensions: 
40 x 90 x 200 mm (should check if they are accurate).

![imagen](https://github.com/iaxo/iaxo-geometry/assets/106647320/fe9b3490-1a55-4398-9e47-e4047fc8e19b)

Tasks:

- [x] Create electronics (Electronics.kt)
- [x] Add electronics to the different configurations (in BabyIAXO/Main.kt and IAXO-D1/Main.kt)
- [x] Check overlaps (in each configuration !)
- [x] Update gdml directory
