### PR TITLE
Detailed electronics

### DIFF
--- a/gdml/BabyIAXO/ChamberAndPipe.gdml
+++ b/gdml/BabyIAXO/ChamberAndPipe.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="worldBox" x="1450.0" y="1600.0" z="1450.0"/>
     </solids>
     <structure>
@@ -4273,46 +4273,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="world">

--- a/gdml/BabyIAXO/CompleteVeto1Layers.gdml
+++ b/gdml/BabyIAXO/CompleteVeto1Layers.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4328,46 +4328,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/BabyIAXO/CompleteVeto2Layers.gdml
+++ b/gdml/BabyIAXO/CompleteVeto2Layers.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4328,46 +4328,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/BabyIAXO/CompleteVeto3Layers.gdml
+++ b/gdml/BabyIAXO/CompleteVeto3Layers.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4328,46 +4328,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/BabyIAXO/CompleteVeto4Layers.gdml
+++ b/gdml/BabyIAXO/CompleteVeto4Layers.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4328,46 +4328,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/BabyIAXO/Default.gdml
+++ b/gdml/BabyIAXO/Default.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4328,46 +4328,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/BabyIAXO/DefaultXenon.gdml
+++ b/gdml/BabyIAXO/DefaultXenon.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4328,46 +4328,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/BabyIAXO/NoVetoes.gdml
+++ b/gdml/BabyIAXO/NoVetoes.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4287,46 +4287,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/BabyIAXO/NoVetoesDetailedElectronics.gdml
+++ b/gdml/BabyIAXO/NoVetoesDetailedElectronics.gdml
@@ -4143,10 +4143,10 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
-        <box lunit="mm" aunit="rad" name="chipSolid" x="1.0" y="25.0" z="25.0"/>
-        <box lunit="mm" aunit="rad" name="componentsSolid" x="1.0" y="40.0" z="5.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
+        <box lunit="mm" aunit="rad" name="chipSolid" x="1.0" y="28.0" z="28.0"/>
+        <box lunit="mm" aunit="rad" name="componentsSolid" x="1.0" y="76.2" z="9.3"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4289,13 +4289,21 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <volume name="chipVolume">
             <materialref ref="G4_Si"/>
@@ -4306,69 +4314,101 @@
             <solidref ref="componentsSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
             <physvol name="chip1">
                 <volumeref ref="chipVolume"/>
-                <position name="chip1.position" x="-13.25" unit="mm"/>
-            </physvol>
-            <physvol name="chip2">
-                <volumeref ref="chipVolume"/>
-                <position name="chip2.position" x="-3.25" unit="mm"/>
-            </physvol>
-            <physvol name="chip3">
-                <volumeref ref="chipVolume"/>
-                <position name="chip3.position" x="6.75" unit="mm"/>
-            </physvol>
-            <physvol name="chip4">
-                <volumeref ref="chipVolume"/>
-                <position name="chip4.position" x="16.75" unit="mm"/>
+                <position name="chip1.position" x="-14.19" z="38.1" unit="mm"/>
             </physvol>
             <physvol name="components1">
                 <volumeref ref="componentsVolume"/>
-                <position name="components1.position" x="-13.25" z="-30.0" unit="mm"/>
+                <position name="components1.position" x="-14.19" z="-38.1" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="chip2">
+                <volumeref ref="chipVolume"/>
+                <position name="chip2.position" x="-4.19" z="38.1" unit="mm"/>
             </physvol>
             <physvol name="components2">
                 <volumeref ref="componentsVolume"/>
-                <position name="components2.position" x="-3.25" z="-30.0" unit="mm"/>
+                <position name="components2.position" x="-4.19" z="-38.1" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="chip3">
+                <volumeref ref="chipVolume"/>
+                <position name="chip3.position" x="5.81" z="38.1" unit="mm"/>
             </physvol>
             <physvol name="components3">
                 <volumeref ref="componentsVolume"/>
-                <position name="components3.position" x="6.75" z="-30.0" unit="mm"/>
+                <position name="components3.position" x="5.81" z="-38.1" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="chip4">
+                <volumeref ref="chipVolume"/>
+                <position name="chip4.position" x="15.81" z="38.1" unit="mm"/>
             </physvol>
             <physvol name="components4">
                 <volumeref ref="componentsVolume"/>
-                <position name="components4.position" x="16.75" z="-30.0" unit="mm"/>
-            </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
-            </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
-            </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
-            </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+                <position name="components4.position" x="15.81" z="-38.1" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/BabyIAXO/NoVetoesDetailedElectronics.gdml
+++ b/gdml/BabyIAXO/NoVetoesDetailedElectronics.gdml
@@ -1,0 +1,4414 @@
+<?xml version='1.0'?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+    <define/>
+    <materials>
+        <isotope Z="1.0" N="1" name="H1">
+            <atom value="1.007825" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="1.0" N="2" name="H2">
+            <atom value="2.014102" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="H">
+            <fraction n="0.999885" ref="H1"/>
+            <fraction n="1.15E-4" ref="H2"/>
+        </element>
+        <isotope Z="2.0" N="3" name="He3">
+            <atom value="3.01693" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="2.0" N="4" name="He4">
+            <atom value="4.002644" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="He">
+            <fraction n="1.0E-6" ref="He3"/>
+            <fraction n="0.999999" ref="He4"/>
+        </element>
+        <isotope Z="3.0" N="6" name="Li6">
+            <atom value="6.01512" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="3.0" N="7" name="Li7">
+            <atom value="7.016" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Li">
+            <fraction n="0.0759" ref="Li6"/>
+            <fraction n="0.9241" ref="Li7"/>
+        </element>
+        <isotope Z="4.0" N="9" name="Be9">
+            <atom value="9.01218" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Be">
+            <fraction n="1.0" ref="Be9"/>
+        </element>
+        <isotope Z="5.0" N="10" name="B10">
+            <atom value="10.0129" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="5.0" N="11" name="B11">
+            <atom value="11.0093" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="B">
+            <fraction n="0.199" ref="B10"/>
+            <fraction n="0.801" ref="B11"/>
+        </element>
+        <isotope Z="6.0" N="12" name="C12">
+            <atom value="12.0" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="6.0" N="13" name="C13">
+            <atom value="13.0034" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="C">
+            <fraction n="0.9893" ref="C12"/>
+            <fraction n="0.0107" ref="C13"/>
+        </element>
+        <isotope Z="7.0" N="14" name="N14">
+            <atom value="14.0031" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="7.0" N="15" name="N15">
+            <atom value="15.0001" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="N">
+            <fraction n="0.99632" ref="N14"/>
+            <fraction n="0.00368" ref="N15"/>
+        </element>
+        <isotope Z="8.0" N="16" name="O16">
+            <atom value="15.9949" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="8.0" N="17" name="O17">
+            <atom value="16.9991" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="8.0" N="18" name="O18">
+            <atom value="17.9992" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="O">
+            <fraction n="0.99757" ref="O16"/>
+            <fraction n="3.8E-4" ref="O17"/>
+            <fraction n="0.00205" ref="O18"/>
+        </element>
+        <isotope Z="9.0" N="19" name="F19">
+            <atom value="18.9984" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="F">
+            <fraction n="1.0" ref="F19"/>
+        </element>
+        <isotope Z="10.0" N="20" name="Ne20">
+            <atom value="19.9924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="10.0" N="21" name="Ne21">
+            <atom value="20.9938" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="10.0" N="22" name="Ne22">
+            <atom value="21.9914" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ne">
+            <fraction n="0.9048" ref="Ne20"/>
+            <fraction n="0.0027" ref="Ne21"/>
+            <fraction n="0.0925" ref="Ne22"/>
+        </element>
+        <isotope Z="11.0" N="23" name="Na23">
+            <atom value="22.9898" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Na">
+            <fraction n="1.0" ref="Na23"/>
+        </element>
+        <isotope Z="12.0" N="24" name="Mg24">
+            <atom value="23.985" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="12.0" N="25" name="Mg25">
+            <atom value="24.9858" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="12.0" N="26" name="Mg26">
+            <atom value="25.9826" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Mg">
+            <fraction n="0.7899" ref="Mg24"/>
+            <fraction n="0.1" ref="Mg25"/>
+            <fraction n="0.1101" ref="Mg26"/>
+        </element>
+        <isotope Z="13.0" N="27" name="Al27">
+            <atom value="26.9815" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Al">
+            <fraction n="1.0" ref="Al27"/>
+        </element>
+        <isotope Z="14.0" N="28" name="Si28">
+            <atom value="27.9769" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="14.0" N="29" name="Si29">
+            <atom value="28.9765" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="14.0" N="30" name="Si30">
+            <atom value="29.9738" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Si">
+            <fraction n="0.922296" ref="Si28"/>
+            <fraction n="0.046832" ref="Si29"/>
+            <fraction n="0.030872" ref="Si30"/>
+        </element>
+        <isotope Z="15.0" N="31" name="P31">
+            <atom value="30.9738" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="P">
+            <fraction n="1.0" ref="P31"/>
+        </element>
+        <isotope Z="16.0" N="32" name="S32">
+            <atom value="31.9721" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="16.0" N="33" name="S33">
+            <atom value="32.9715" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="16.0" N="34" name="S34">
+            <atom value="33.9679" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="16.0" N="36" name="S36">
+            <atom value="35.9671" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="S">
+            <fraction n="0.9493" ref="S32"/>
+            <fraction n="0.0076" ref="S33"/>
+            <fraction n="0.0429" ref="S34"/>
+            <fraction n="2.0E-4" ref="S36"/>
+        </element>
+        <isotope Z="17.0" N="35" name="Cl35">
+            <atom value="34.9689" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="17.0" N="37" name="Cl37">
+            <atom value="36.9659" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cl">
+            <fraction n="0.7578" ref="Cl35"/>
+            <fraction n="0.2422" ref="Cl37"/>
+        </element>
+        <isotope Z="18.0" N="36" name="Ar36">
+            <atom value="35.9675" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="18.0" N="38" name="Ar38">
+            <atom value="37.9627" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="18.0" N="40" name="Ar40">
+            <atom value="39.9624" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ar">
+            <fraction n="0.003365" ref="Ar36"/>
+            <fraction n="6.32E-4" ref="Ar38"/>
+            <fraction n="0.996003" ref="Ar40"/>
+        </element>
+        <isotope Z="19.0" N="39" name="K39">
+            <atom value="38.9637" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="19.0" N="40" name="K40">
+            <atom value="39.964" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="19.0" N="41" name="K41">
+            <atom value="40.9618" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="K">
+            <fraction n="0.932581" ref="K39"/>
+            <fraction n="1.17E-4" ref="K40"/>
+            <fraction n="0.067302" ref="K41"/>
+        </element>
+        <isotope Z="20.0" N="40" name="Ca40">
+            <atom value="39.9626" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="42" name="Ca42">
+            <atom value="41.9586" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="43" name="Ca43">
+            <atom value="42.9588" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="44" name="Ca44">
+            <atom value="43.9555" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="46" name="Ca46">
+            <atom value="45.9537" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="48" name="Ca48">
+            <atom value="47.9525" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ca">
+            <fraction n="0.96941" ref="Ca40"/>
+            <fraction n="0.00647" ref="Ca42"/>
+            <fraction n="0.00135" ref="Ca43"/>
+            <fraction n="0.02086" ref="Ca44"/>
+            <fraction n="4.0E-5" ref="Ca46"/>
+            <fraction n="0.00187" ref="Ca48"/>
+        </element>
+        <isotope Z="21.0" N="45" name="Sc45">
+            <atom value="44.9559" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sc">
+            <fraction n="1.0" ref="Sc45"/>
+        </element>
+        <isotope Z="22.0" N="46" name="Ti46">
+            <atom value="45.9526" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="22.0" N="47" name="Ti47">
+            <atom value="46.9518" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="22.0" N="48" name="Ti48">
+            <atom value="47.9479" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="22.0" N="49" name="Ti49">
+            <atom value="48.9479" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="22.0" N="50" name="Ti50">
+            <atom value="49.9448" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ti">
+            <fraction n="0.0825" ref="Ti46"/>
+            <fraction n="0.0744" ref="Ti47"/>
+            <fraction n="0.7372" ref="Ti48"/>
+            <fraction n="0.0541" ref="Ti49"/>
+            <fraction n="0.0518" ref="Ti50"/>
+        </element>
+        <isotope Z="23.0" N="50" name="V50">
+            <atom value="49.9472" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="23.0" N="51" name="V51">
+            <atom value="50.944" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="V">
+            <fraction n="0.0025" ref="V50"/>
+            <fraction n="0.9975" ref="V51"/>
+        </element>
+        <isotope Z="24.0" N="50" name="Cr50">
+            <atom value="49.946" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="24.0" N="52" name="Cr52">
+            <atom value="51.9405" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="24.0" N="53" name="Cr53">
+            <atom value="52.9407" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="24.0" N="54" name="Cr54">
+            <atom value="53.9389" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cr">
+            <fraction n="0.04345" ref="Cr50"/>
+            <fraction n="0.83789" ref="Cr52"/>
+            <fraction n="0.09501" ref="Cr53"/>
+            <fraction n="0.02365" ref="Cr54"/>
+        </element>
+        <isotope Z="25.0" N="55" name="Mn55">
+            <atom value="54.938" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Mn">
+            <fraction n="1.0" ref="Mn55"/>
+        </element>
+        <isotope Z="26.0" N="54" name="Fe54">
+            <atom value="53.9396" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="26.0" N="56" name="Fe56">
+            <atom value="55.9349" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="26.0" N="57" name="Fe57">
+            <atom value="56.9354" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="26.0" N="58" name="Fe58">
+            <atom value="57.9333" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Fe">
+            <fraction n="0.05845" ref="Fe54"/>
+            <fraction n="0.91754" ref="Fe56"/>
+            <fraction n="0.02119" ref="Fe57"/>
+            <fraction n="0.00282" ref="Fe58"/>
+        </element>
+        <isotope Z="27.0" N="59" name="Co59">
+            <atom value="58.9332" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Co">
+            <fraction n="1.0" ref="Co59"/>
+        </element>
+        <isotope Z="28.0" N="58" name="Ni58">
+            <atom value="57.9353" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="28.0" N="60" name="Ni60">
+            <atom value="59.9308" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="28.0" N="61" name="Ni61">
+            <atom value="60.9311" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="28.0" N="62" name="Ni62">
+            <atom value="61.9283" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="28.0" N="64" name="Ni64">
+            <atom value="63.928" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ni">
+            <fraction n="0.680769" ref="Ni58"/>
+            <fraction n="0.262231" ref="Ni60"/>
+            <fraction n="0.011399" ref="Ni61"/>
+            <fraction n="0.036345" ref="Ni62"/>
+            <fraction n="0.009256" ref="Ni64"/>
+        </element>
+        <isotope Z="29.0" N="63" name="Cu63">
+            <atom value="62.9296" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="29.0" N="65" name="Cu65">
+            <atom value="64.9278" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cu">
+            <fraction n="0.6917" ref="Cu63"/>
+            <fraction n="0.3083" ref="Cu65"/>
+        </element>
+        <isotope Z="30.0" N="64" name="Zn64">
+            <atom value="63.9291" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="30.0" N="66" name="Zn66">
+            <atom value="65.926" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="30.0" N="67" name="Zn67">
+            <atom value="66.9271" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="30.0" N="68" name="Zn68">
+            <atom value="67.9248" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="30.0" N="70" name="Zn70">
+            <atom value="69.9253" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Zn">
+            <fraction n="0.4863" ref="Zn64"/>
+            <fraction n="0.279" ref="Zn66"/>
+            <fraction n="0.041" ref="Zn67"/>
+            <fraction n="0.1875" ref="Zn68"/>
+            <fraction n="0.0062" ref="Zn70"/>
+        </element>
+        <isotope Z="31.0" N="69" name="Ga69">
+            <atom value="68.9256" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="31.0" N="71" name="Ga71">
+            <atom value="70.9247" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ga">
+            <fraction n="0.60108" ref="Ga69"/>
+            <fraction n="0.39892" ref="Ga71"/>
+        </element>
+        <isotope Z="32.0" N="70" name="Ge70">
+            <atom value="69.9243" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="32.0" N="72" name="Ge72">
+            <atom value="71.9221" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="32.0" N="73" name="Ge73">
+            <atom value="72.9235" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="32.0" N="74" name="Ge74">
+            <atom value="73.9212" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="32.0" N="76" name="Ge76">
+            <atom value="75.9214" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ge">
+            <fraction n="0.2084" ref="Ge70"/>
+            <fraction n="0.2754" ref="Ge72"/>
+            <fraction n="0.0773" ref="Ge73"/>
+            <fraction n="0.3628" ref="Ge74"/>
+            <fraction n="0.0761" ref="Ge76"/>
+        </element>
+        <isotope Z="33.0" N="75" name="As75">
+            <atom value="74.9216" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="As">
+            <fraction n="1.0" ref="As75"/>
+        </element>
+        <isotope Z="34.0" N="74" name="Se74">
+            <atom value="73.9225" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="76" name="Se76">
+            <atom value="75.9192" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="77" name="Se77">
+            <atom value="76.9199" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="78" name="Se78">
+            <atom value="77.9173" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="80" name="Se80">
+            <atom value="79.9165" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="82" name="Se82">
+            <atom value="81.9167" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Se">
+            <fraction n="0.0089" ref="Se74"/>
+            <fraction n="0.0937" ref="Se76"/>
+            <fraction n="0.0763" ref="Se77"/>
+            <fraction n="0.2377" ref="Se78"/>
+            <fraction n="0.4961" ref="Se80"/>
+            <fraction n="0.0873" ref="Se82"/>
+        </element>
+        <isotope Z="35.0" N="79" name="Br79">
+            <atom value="78.9183" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="35.0" N="81" name="Br81">
+            <atom value="80.9163" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Br">
+            <fraction n="0.5069" ref="Br79"/>
+            <fraction n="0.4931" ref="Br81"/>
+        </element>
+        <isotope Z="36.0" N="78" name="Kr78">
+            <atom value="77.9204" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="80" name="Kr80">
+            <atom value="79.9164" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="82" name="Kr82">
+            <atom value="81.9135" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="83" name="Kr83">
+            <atom value="82.9141" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="84" name="Kr84">
+            <atom value="83.9115" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="86" name="Kr86">
+            <atom value="85.9106" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Kr">
+            <fraction n="0.0035" ref="Kr78"/>
+            <fraction n="0.0228" ref="Kr80"/>
+            <fraction n="0.1158" ref="Kr82"/>
+            <fraction n="0.1149" ref="Kr83"/>
+            <fraction n="0.57" ref="Kr84"/>
+            <fraction n="0.173" ref="Kr86"/>
+        </element>
+        <isotope Z="37.0" N="85" name="Rb85">
+            <atom value="84.9118" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="37.0" N="87" name="Rb87">
+            <atom value="86.9092" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Rb">
+            <fraction n="0.7217" ref="Rb85"/>
+            <fraction n="0.2783" ref="Rb87"/>
+        </element>
+        <isotope Z="38.0" N="84" name="Sr84">
+            <atom value="83.9134" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="38.0" N="86" name="Sr86">
+            <atom value="85.9093" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="38.0" N="87" name="Sr87">
+            <atom value="86.9089" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="38.0" N="88" name="Sr88">
+            <atom value="87.9056" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sr">
+            <fraction n="0.0056" ref="Sr84"/>
+            <fraction n="0.0986" ref="Sr86"/>
+            <fraction n="0.07" ref="Sr87"/>
+            <fraction n="0.8258" ref="Sr88"/>
+        </element>
+        <isotope Z="39.0" N="89" name="Y89">
+            <atom value="88.9058" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Y">
+            <fraction n="1.0" ref="Y89"/>
+        </element>
+        <isotope Z="40.0" N="90" name="Zr90">
+            <atom value="89.9047" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="40.0" N="91" name="Zr91">
+            <atom value="90.9056" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="40.0" N="92" name="Zr92">
+            <atom value="91.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="40.0" N="94" name="Zr94">
+            <atom value="93.9063" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="40.0" N="96" name="Zr96">
+            <atom value="95.9083" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Zr">
+            <fraction n="0.5145" ref="Zr90"/>
+            <fraction n="0.1122" ref="Zr91"/>
+            <fraction n="0.1715" ref="Zr92"/>
+            <fraction n="0.1738" ref="Zr94"/>
+            <fraction n="0.028" ref="Zr96"/>
+        </element>
+        <isotope Z="41.0" N="93" name="Nb93">
+            <atom value="92.9064" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Nb">
+            <fraction n="1.0" ref="Nb93"/>
+        </element>
+        <isotope Z="42.0" N="92" name="Mo92">
+            <atom value="91.9068" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="94" name="Mo94">
+            <atom value="93.9051" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="95" name="Mo95">
+            <atom value="94.9058" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="96" name="Mo96">
+            <atom value="95.9047" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="97" name="Mo97">
+            <atom value="96.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="98" name="Mo98">
+            <atom value="97.9054" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="100" name="Mo100">
+            <atom value="99.9075" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Mo">
+            <fraction n="0.1484" ref="Mo92"/>
+            <fraction n="0.0925" ref="Mo94"/>
+            <fraction n="0.1592" ref="Mo95"/>
+            <fraction n="0.1668" ref="Mo96"/>
+            <fraction n="0.0955" ref="Mo97"/>
+            <fraction n="0.2413" ref="Mo98"/>
+            <fraction n="0.0963" ref="Mo100"/>
+        </element>
+        <isotope Z="43.0" N="98" name="Tc98">
+            <atom value="97.9072" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Tc">
+            <fraction n="1.0" ref="Tc98"/>
+        </element>
+        <isotope Z="44.0" N="96" name="Ru96">
+            <atom value="95.9076" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="98" name="Ru98">
+            <atom value="97.9053" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="99" name="Ru99">
+            <atom value="98.9059" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="100" name="Ru100">
+            <atom value="99.9042" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="101" name="Ru101">
+            <atom value="100.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="102" name="Ru102">
+            <atom value="101.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="104" name="Ru104">
+            <atom value="103.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ru">
+            <fraction n="0.0554" ref="Ru96"/>
+            <fraction n="0.0187" ref="Ru98"/>
+            <fraction n="0.1276" ref="Ru99"/>
+            <fraction n="0.126" ref="Ru100"/>
+            <fraction n="0.1706" ref="Ru101"/>
+            <fraction n="0.3155" ref="Ru102"/>
+            <fraction n="0.1862" ref="Ru104"/>
+        </element>
+        <isotope Z="45.0" N="103" name="Rh103">
+            <atom value="102.906" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Rh">
+            <fraction n="1.0" ref="Rh103"/>
+        </element>
+        <isotope Z="46.0" N="102" name="Pd102">
+            <atom value="101.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="104" name="Pd104">
+            <atom value="103.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="105" name="Pd105">
+            <atom value="104.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="106" name="Pd106">
+            <atom value="105.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="108" name="Pd108">
+            <atom value="107.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="110" name="Pd110">
+            <atom value="109.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pd">
+            <fraction n="0.0102" ref="Pd102"/>
+            <fraction n="0.1114" ref="Pd104"/>
+            <fraction n="0.2233" ref="Pd105"/>
+            <fraction n="0.2733" ref="Pd106"/>
+            <fraction n="0.2646" ref="Pd108"/>
+            <fraction n="0.1172" ref="Pd110"/>
+        </element>
+        <isotope Z="47.0" N="107" name="Ag107">
+            <atom value="106.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="47.0" N="109" name="Ag109">
+            <atom value="108.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ag">
+            <fraction n="0.51839" ref="Ag107"/>
+            <fraction n="0.48161" ref="Ag109"/>
+        </element>
+        <isotope Z="48.0" N="106" name="Cd106">
+            <atom value="105.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="108" name="Cd108">
+            <atom value="107.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="110" name="Cd110">
+            <atom value="109.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="111" name="Cd111">
+            <atom value="110.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="112" name="Cd112">
+            <atom value="111.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="113" name="Cd113">
+            <atom value="112.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="114" name="Cd114">
+            <atom value="113.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="116" name="Cd116">
+            <atom value="115.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cd">
+            <fraction n="0.0125" ref="Cd106"/>
+            <fraction n="0.0089" ref="Cd108"/>
+            <fraction n="0.1249" ref="Cd110"/>
+            <fraction n="0.128" ref="Cd111"/>
+            <fraction n="0.2413" ref="Cd112"/>
+            <fraction n="0.1222" ref="Cd113"/>
+            <fraction n="0.2873" ref="Cd114"/>
+            <fraction n="0.0749" ref="Cd116"/>
+        </element>
+        <isotope Z="49.0" N="113" name="In113">
+            <atom value="112.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="49.0" N="115" name="In115">
+            <atom value="114.904" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="In">
+            <fraction n="0.0429" ref="In113"/>
+            <fraction n="0.9571" ref="In115"/>
+        </element>
+        <isotope Z="50.0" N="112" name="Sn112">
+            <atom value="111.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="114" name="Sn114">
+            <atom value="113.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="115" name="Sn115">
+            <atom value="114.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="116" name="Sn116">
+            <atom value="115.902" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="117" name="Sn117">
+            <atom value="116.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="118" name="Sn118">
+            <atom value="117.902" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="119" name="Sn119">
+            <atom value="118.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="120" name="Sn120">
+            <atom value="119.902" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="122" name="Sn122">
+            <atom value="121.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="124" name="Sn124">
+            <atom value="123.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sn">
+            <fraction n="0.0097" ref="Sn112"/>
+            <fraction n="0.0066" ref="Sn114"/>
+            <fraction n="0.0034" ref="Sn115"/>
+            <fraction n="0.1454" ref="Sn116"/>
+            <fraction n="0.0768" ref="Sn117"/>
+            <fraction n="0.2422" ref="Sn118"/>
+            <fraction n="0.0859" ref="Sn119"/>
+            <fraction n="0.3258" ref="Sn120"/>
+            <fraction n="0.0463" ref="Sn122"/>
+            <fraction n="0.0579" ref="Sn124"/>
+        </element>
+        <isotope Z="51.0" N="121" name="Sb121">
+            <atom value="120.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="51.0" N="123" name="Sb123">
+            <atom value="122.904" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sb">
+            <fraction n="0.5721" ref="Sb121"/>
+            <fraction n="0.4279" ref="Sb123"/>
+        </element>
+        <isotope Z="52.0" N="120" name="Te120">
+            <atom value="119.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="122" name="Te122">
+            <atom value="121.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="123" name="Te123">
+            <atom value="122.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="124" name="Te124">
+            <atom value="123.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="125" name="Te125">
+            <atom value="124.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="126" name="Te126">
+            <atom value="125.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="128" name="Te128">
+            <atom value="127.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="130" name="Te130">
+            <atom value="129.906" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Te">
+            <fraction n="9.0E-4" ref="Te120"/>
+            <fraction n="0.0255" ref="Te122"/>
+            <fraction n="0.0089" ref="Te123"/>
+            <fraction n="0.0474" ref="Te124"/>
+            <fraction n="0.0707" ref="Te125"/>
+            <fraction n="0.1884" ref="Te126"/>
+            <fraction n="0.3174" ref="Te128"/>
+            <fraction n="0.3408" ref="Te130"/>
+        </element>
+        <isotope Z="53.0" N="127" name="I127">
+            <atom value="126.904" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="I">
+            <fraction n="1.0" ref="I127"/>
+        </element>
+        <isotope Z="54.0" N="124" name="Xe124">
+            <atom value="123.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="126" name="Xe126">
+            <atom value="125.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="128" name="Xe128">
+            <atom value="127.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="129" name="Xe129">
+            <atom value="128.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="130" name="Xe130">
+            <atom value="129.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="131" name="Xe131">
+            <atom value="130.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="132" name="Xe132">
+            <atom value="131.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="134" name="Xe134">
+            <atom value="133.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="136" name="Xe136">
+            <atom value="135.907" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Xe">
+            <fraction n="9.0E-4" ref="Xe124"/>
+            <fraction n="9.0E-4" ref="Xe126"/>
+            <fraction n="0.0192" ref="Xe128"/>
+            <fraction n="0.2644" ref="Xe129"/>
+            <fraction n="0.0408" ref="Xe130"/>
+            <fraction n="0.2118" ref="Xe131"/>
+            <fraction n="0.2689" ref="Xe132"/>
+            <fraction n="0.1044" ref="Xe134"/>
+            <fraction n="0.0887" ref="Xe136"/>
+        </element>
+        <isotope Z="55.0" N="133" name="Cs133">
+            <atom value="132.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cs">
+            <fraction n="1.0" ref="Cs133"/>
+        </element>
+        <isotope Z="56.0" N="130" name="Ba130">
+            <atom value="129.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="132" name="Ba132">
+            <atom value="131.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="134" name="Ba134">
+            <atom value="133.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="135" name="Ba135">
+            <atom value="134.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="136" name="Ba136">
+            <atom value="135.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="137" name="Ba137">
+            <atom value="136.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="138" name="Ba138">
+            <atom value="137.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ba">
+            <fraction n="0.00106" ref="Ba130"/>
+            <fraction n="0.00101" ref="Ba132"/>
+            <fraction n="0.02417" ref="Ba134"/>
+            <fraction n="0.06592" ref="Ba135"/>
+            <fraction n="0.07854" ref="Ba136"/>
+            <fraction n="0.11232" ref="Ba137"/>
+            <fraction n="0.71698" ref="Ba138"/>
+        </element>
+        <isotope Z="57.0" N="138" name="La138">
+            <atom value="137.907" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="57.0" N="139" name="La139">
+            <atom value="138.906" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="La">
+            <fraction n="9.0E-4" ref="La138"/>
+            <fraction n="0.9991" ref="La139"/>
+        </element>
+        <isotope Z="58.0" N="136" name="Ce136">
+            <atom value="135.907" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="58.0" N="138" name="Ce138">
+            <atom value="137.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="58.0" N="140" name="Ce140">
+            <atom value="139.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="58.0" N="142" name="Ce142">
+            <atom value="141.909" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ce">
+            <fraction n="0.00185" ref="Ce136"/>
+            <fraction n="0.00251" ref="Ce138"/>
+            <fraction n="0.8845" ref="Ce140"/>
+            <fraction n="0.11114" ref="Ce142"/>
+        </element>
+        <isotope Z="59.0" N="141" name="Pr141">
+            <atom value="140.908" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pr">
+            <fraction n="1.0" ref="Pr141"/>
+        </element>
+        <isotope Z="60.0" N="142" name="Nd142">
+            <atom value="141.908" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="143" name="Nd143">
+            <atom value="142.91" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="144" name="Nd144">
+            <atom value="143.91" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="145" name="Nd145">
+            <atom value="144.913" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="146" name="Nd146">
+            <atom value="145.913" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="148" name="Nd148">
+            <atom value="147.917" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="150" name="Nd150">
+            <atom value="149.921" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Nd">
+            <fraction n="0.272" ref="Nd142"/>
+            <fraction n="0.122" ref="Nd143"/>
+            <fraction n="0.238" ref="Nd144"/>
+            <fraction n="0.083" ref="Nd145"/>
+            <fraction n="0.172" ref="Nd146"/>
+            <fraction n="0.057" ref="Nd148"/>
+            <fraction n="0.056" ref="Nd150"/>
+        </element>
+        <isotope Z="61.0" N="145" name="Pm145">
+            <atom value="144.913" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pm">
+            <fraction n="1.0" ref="Pm145"/>
+        </element>
+        <isotope Z="62.0" N="144" name="Sm144">
+            <atom value="143.912" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="147" name="Sm147">
+            <atom value="146.915" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="148" name="Sm148">
+            <atom value="147.915" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="149" name="Sm149">
+            <atom value="148.917" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="150" name="Sm150">
+            <atom value="149.917" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="152" name="Sm152">
+            <atom value="151.92" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="154" name="Sm154">
+            <atom value="153.922" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sm">
+            <fraction n="0.0307" ref="Sm144"/>
+            <fraction n="0.1499" ref="Sm147"/>
+            <fraction n="0.1124" ref="Sm148"/>
+            <fraction n="0.1382" ref="Sm149"/>
+            <fraction n="0.0738" ref="Sm150"/>
+            <fraction n="0.2675" ref="Sm152"/>
+            <fraction n="0.2275" ref="Sm154"/>
+        </element>
+        <isotope Z="63.0" N="151" name="Eu151">
+            <atom value="150.92" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="63.0" N="153" name="Eu153">
+            <atom value="152.921" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Eu">
+            <fraction n="0.4781" ref="Eu151"/>
+            <fraction n="0.5219" ref="Eu153"/>
+        </element>
+        <isotope Z="64.0" N="152" name="Gd152">
+            <atom value="151.92" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="154" name="Gd154">
+            <atom value="153.921" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="155" name="Gd155">
+            <atom value="154.923" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="156" name="Gd156">
+            <atom value="155.922" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="157" name="Gd157">
+            <atom value="156.924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="158" name="Gd158">
+            <atom value="157.924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="160" name="Gd160">
+            <atom value="159.927" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Gd">
+            <fraction n="0.002" ref="Gd152"/>
+            <fraction n="0.0218" ref="Gd154"/>
+            <fraction n="0.148" ref="Gd155"/>
+            <fraction n="0.2047" ref="Gd156"/>
+            <fraction n="0.1565" ref="Gd157"/>
+            <fraction n="0.2484" ref="Gd158"/>
+            <fraction n="0.2186" ref="Gd160"/>
+        </element>
+        <isotope Z="65.0" N="159" name="Tb159">
+            <atom value="158.925" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Tb">
+            <fraction n="1.0" ref="Tb159"/>
+        </element>
+        <isotope Z="66.0" N="156" name="Dy156">
+            <atom value="155.924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="158" name="Dy158">
+            <atom value="157.924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="160" name="Dy160">
+            <atom value="159.925" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="161" name="Dy161">
+            <atom value="160.927" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="162" name="Dy162">
+            <atom value="161.927" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="163" name="Dy163">
+            <atom value="162.929" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="164" name="Dy164">
+            <atom value="163.929" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Dy">
+            <fraction n="6.0E-4" ref="Dy156"/>
+            <fraction n="0.001" ref="Dy158"/>
+            <fraction n="0.0234" ref="Dy160"/>
+            <fraction n="0.1891" ref="Dy161"/>
+            <fraction n="0.2551" ref="Dy162"/>
+            <fraction n="0.249" ref="Dy163"/>
+            <fraction n="0.2818" ref="Dy164"/>
+        </element>
+        <isotope Z="67.0" N="165" name="Ho165">
+            <atom value="164.93" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ho">
+            <fraction n="1.0" ref="Ho165"/>
+        </element>
+        <isotope Z="68.0" N="162" name="Er162">
+            <atom value="161.929" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="164" name="Er164">
+            <atom value="163.929" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="166" name="Er166">
+            <atom value="165.93" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="167" name="Er167">
+            <atom value="166.932" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="168" name="Er168">
+            <atom value="167.932" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="170" name="Er170">
+            <atom value="169.935" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Er">
+            <fraction n="0.0014" ref="Er162"/>
+            <fraction n="0.0161" ref="Er164"/>
+            <fraction n="0.3361" ref="Er166"/>
+            <fraction n="0.2293" ref="Er167"/>
+            <fraction n="0.2678" ref="Er168"/>
+            <fraction n="0.1493" ref="Er170"/>
+        </element>
+        <isotope Z="69.0" N="169" name="Tm169">
+            <atom value="168.934" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Tm">
+            <fraction n="1.0" ref="Tm169"/>
+        </element>
+        <isotope Z="70.0" N="168" name="Yb168">
+            <atom value="167.934" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="170" name="Yb170">
+            <atom value="169.935" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="171" name="Yb171">
+            <atom value="170.936" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="172" name="Yb172">
+            <atom value="171.936" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="173" name="Yb173">
+            <atom value="172.938" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="174" name="Yb174">
+            <atom value="173.939" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="176" name="Yb176">
+            <atom value="175.943" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Yb">
+            <fraction n="0.0013" ref="Yb168"/>
+            <fraction n="0.0304" ref="Yb170"/>
+            <fraction n="0.1428" ref="Yb171"/>
+            <fraction n="0.2183" ref="Yb172"/>
+            <fraction n="0.1613" ref="Yb173"/>
+            <fraction n="0.3183" ref="Yb174"/>
+            <fraction n="0.1276" ref="Yb176"/>
+        </element>
+        <isotope Z="71.0" N="175" name="Lu175">
+            <atom value="174.941" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="71.0" N="176" name="Lu176">
+            <atom value="175.943" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Lu">
+            <fraction n="0.9741" ref="Lu175"/>
+            <fraction n="0.0259" ref="Lu176"/>
+        </element>
+        <isotope Z="72.0" N="174" name="Hf174">
+            <atom value="173.94" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="176" name="Hf176">
+            <atom value="175.941" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="177" name="Hf177">
+            <atom value="176.943" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="178" name="Hf178">
+            <atom value="177.944" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="179" name="Hf179">
+            <atom value="178.946" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="180" name="Hf180">
+            <atom value="179.947" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Hf">
+            <fraction n="0.0016" ref="Hf174"/>
+            <fraction n="0.0526" ref="Hf176"/>
+            <fraction n="0.186" ref="Hf177"/>
+            <fraction n="0.2728" ref="Hf178"/>
+            <fraction n="0.1362" ref="Hf179"/>
+            <fraction n="0.3508" ref="Hf180"/>
+        </element>
+        <isotope Z="73.0" N="180" name="Ta180">
+            <atom value="179.947" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="73.0" N="181" name="Ta181">
+            <atom value="180.948" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ta">
+            <fraction n="1.2E-4" ref="Ta180"/>
+            <fraction n="0.99988" ref="Ta181"/>
+        </element>
+        <isotope Z="74.0" N="180" name="W180">
+            <atom value="179.947" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="74.0" N="182" name="W182">
+            <atom value="181.948" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="74.0" N="183" name="W183">
+            <atom value="182.95" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="74.0" N="184" name="W184">
+            <atom value="183.951" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="74.0" N="186" name="W186">
+            <atom value="185.954" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="W">
+            <fraction n="0.0012" ref="W180"/>
+            <fraction n="0.265" ref="W182"/>
+            <fraction n="0.1431" ref="W183"/>
+            <fraction n="0.3064" ref="W184"/>
+            <fraction n="0.2843" ref="W186"/>
+        </element>
+        <isotope Z="75.0" N="185" name="Re185">
+            <atom value="184.953" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="75.0" N="187" name="Re187">
+            <atom value="186.956" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Re">
+            <fraction n="0.374" ref="Re185"/>
+            <fraction n="0.626" ref="Re187"/>
+        </element>
+        <isotope Z="76.0" N="184" name="Os184">
+            <atom value="183.952" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="186" name="Os186">
+            <atom value="185.954" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="187" name="Os187">
+            <atom value="186.956" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="188" name="Os188">
+            <atom value="187.956" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="189" name="Os189">
+            <atom value="188.958" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="190" name="Os190">
+            <atom value="189.958" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="192" name="Os192">
+            <atom value="191.961" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Os">
+            <fraction n="2.0E-4" ref="Os184"/>
+            <fraction n="0.0159" ref="Os186"/>
+            <fraction n="0.0196" ref="Os187"/>
+            <fraction n="0.1324" ref="Os188"/>
+            <fraction n="0.1615" ref="Os189"/>
+            <fraction n="0.2626" ref="Os190"/>
+            <fraction n="0.4078" ref="Os192"/>
+        </element>
+        <isotope Z="77.0" N="191" name="Ir191">
+            <atom value="190.961" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="77.0" N="193" name="Ir193">
+            <atom value="192.963" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ir">
+            <fraction n="0.373" ref="Ir191"/>
+            <fraction n="0.627" ref="Ir193"/>
+        </element>
+        <isotope Z="78.0" N="190" name="Pt190">
+            <atom value="189.96" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="192" name="Pt192">
+            <atom value="191.961" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="194" name="Pt194">
+            <atom value="193.963" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="195" name="Pt195">
+            <atom value="194.965" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="196" name="Pt196">
+            <atom value="195.965" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="198" name="Pt198">
+            <atom value="197.968" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pt">
+            <fraction n="1.4E-4" ref="Pt190"/>
+            <fraction n="0.00782" ref="Pt192"/>
+            <fraction n="0.32967" ref="Pt194"/>
+            <fraction n="0.33832" ref="Pt195"/>
+            <fraction n="0.25242" ref="Pt196"/>
+            <fraction n="0.07163" ref="Pt198"/>
+        </element>
+        <isotope Z="79.0" N="197" name="Au197">
+            <atom value="196.967" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Au">
+            <fraction n="1.0" ref="Au197"/>
+        </element>
+        <isotope Z="80.0" N="196" name="Hg196">
+            <atom value="195.966" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="198" name="Hg198">
+            <atom value="197.967" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="199" name="Hg199">
+            <atom value="198.968" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="200" name="Hg200">
+            <atom value="199.968" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="201" name="Hg201">
+            <atom value="200.97" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="202" name="Hg202">
+            <atom value="201.971" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="204" name="Hg204">
+            <atom value="203.973" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Hg">
+            <fraction n="0.0015" ref="Hg196"/>
+            <fraction n="0.0997" ref="Hg198"/>
+            <fraction n="0.1687" ref="Hg199"/>
+            <fraction n="0.231" ref="Hg200"/>
+            <fraction n="0.1318" ref="Hg201"/>
+            <fraction n="0.2986" ref="Hg202"/>
+            <fraction n="0.0687" ref="Hg204"/>
+        </element>
+        <isotope Z="81.0" N="203" name="Tl203">
+            <atom value="202.972" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="81.0" N="205" name="Tl205">
+            <atom value="204.974" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Tl">
+            <fraction n="0.29524" ref="Tl203"/>
+            <fraction n="0.70476" ref="Tl205"/>
+        </element>
+        <isotope Z="82.0" N="204" name="Pb204">
+            <atom value="203.973" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="206" name="Pb206">
+            <atom value="205.974" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="207" name="Pb207">
+            <atom value="206.976" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="208" name="Pb208">
+            <atom value="207.977" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pb">
+            <fraction n="0.014" ref="Pb204"/>
+            <fraction n="0.241" ref="Pb206"/>
+            <fraction n="0.221" ref="Pb207"/>
+            <fraction n="0.524" ref="Pb208"/>
+        </element>
+        <isotope Z="83.0" N="209" name="Bi209">
+            <atom value="208.98" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Bi">
+            <fraction n="1.0" ref="Bi209"/>
+        </element>
+        <isotope Z="84.0" N="209" name="Po209">
+            <atom value="208.982" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Po">
+            <fraction n="1.0" ref="Po209"/>
+        </element>
+        <isotope Z="85.0" N="210" name="At210">
+            <atom value="209.987" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="At">
+            <fraction n="1.0" ref="At210"/>
+        </element>
+        <isotope Z="86.0" N="222" name="Rn222">
+            <atom value="222.018" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Rn">
+            <fraction n="1.0" ref="Rn222"/>
+        </element>
+        <isotope Z="87.0" N="223" name="Fr223">
+            <atom value="223.02" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Fr">
+            <fraction n="1.0" ref="Fr223"/>
+        </element>
+        <isotope Z="88.0" N="226" name="Ra226">
+            <atom value="226.025" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ra">
+            <fraction n="1.0" ref="Ra226"/>
+        </element>
+        <isotope Z="89.0" N="227" name="Ac227">
+            <atom value="227.028" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ac">
+            <fraction n="1.0" ref="Ac227"/>
+        </element>
+        <isotope Z="90.0" N="232" name="Th232">
+            <atom value="232.038" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Th">
+            <fraction n="1.0" ref="Th232"/>
+        </element>
+        <isotope Z="91.0" N="231" name="Pa231">
+            <atom value="231.036" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pa">
+            <fraction n="1.0" ref="Pa231"/>
+        </element>
+        <isotope Z="92.0" N="234" name="U234">
+            <atom value="234.041" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="92.0" N="235" name="U235">
+            <atom value="235.044" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="92.0" N="238" name="U238">
+            <atom value="238.051" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="U">
+            <fraction n="5.5E-5" ref="U234"/>
+            <fraction n="0.0072" ref="U235"/>
+            <fraction n="0.992745" ref="U238"/>
+        </element>
+        <isotope Z="93.0" N="237" name="Np237">
+            <atom value="237.048" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Np">
+            <fraction n="1.0" ref="Np237"/>
+        </element>
+        <isotope Z="94.0" N="244" name="Pu244">
+            <atom value="244.064" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pu">
+            <fraction n="1.0" ref="Pu244"/>
+        </element>
+        <isotope Z="95.0" N="243" name="Am243">
+            <atom value="243.061" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Am">
+            <fraction n="1.0" ref="Am243"/>
+        </element>
+        <isotope Z="96.0" N="247" name="Cm247">
+            <atom value="247.07" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cm">
+            <fraction n="1.0" ref="Cm247"/>
+        </element>
+        <isotope Z="97.0" N="247" name="Bk247">
+            <atom value="247.07" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Bk">
+            <fraction n="1.0" ref="Bk247"/>
+        </element>
+        <isotope Z="98.0" N="251" name="Cf251">
+            <atom value="251.08" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cf">
+            <fraction n="1.0" ref="Cf251"/>
+        </element>
+        <material state="solid" name="G4_WATER">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.111898" ref="H"/>
+            <fraction n="0.888102" ref="O"/>
+        </material>
+        <material state="gas" name="G4_H">
+            <D value="8.3748E-5" unit="g/cm3"/>
+            <fraction n="1.0" ref="H"/>
+        </material>
+        <material state="gas" name="G4_He">
+            <D value="1.66322E-4" unit="g/cm3"/>
+            <fraction n="1.0" ref="He"/>
+        </material>
+        <material state="solid" name="G4_Li">
+            <D value="0.534" unit="g/cm3"/>
+            <fraction n="1.0" ref="Li"/>
+        </material>
+        <material state="solid" name="G4_Be">
+            <D value="1.848" unit="g/cm3"/>
+            <fraction n="1.0" ref="Be"/>
+        </material>
+        <material state="solid" name="G4_B">
+            <D value="2.37" unit="g/cm3"/>
+            <fraction n="1.0" ref="B"/>
+        </material>
+        <material state="solid" name="G4_C">
+            <D value="2.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="C"/>
+        </material>
+        <material state="gas" name="G4_N">
+            <D value="0.0011652" unit="g/cm3"/>
+            <fraction n="1.0" ref="N"/>
+        </material>
+        <material state="gas" name="G4_O">
+            <D value="0.00133151" unit="g/cm3"/>
+            <fraction n="1.0" ref="O"/>
+        </material>
+        <material state="gas" name="G4_F">
+            <D value="0.00158029" unit="g/cm3"/>
+            <fraction n="1.0" ref="F"/>
+        </material>
+        <material state="gas" name="G4_Ne">
+            <D value="8.38505E-4" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ne"/>
+        </material>
+        <material state="solid" name="G4_Na">
+            <D value="0.971" unit="g/cm3"/>
+            <fraction n="1.0" ref="Na"/>
+        </material>
+        <material state="solid" name="G4_Mg">
+            <D value="1.74" unit="g/cm3"/>
+            <fraction n="1.0" ref="Mg"/>
+        </material>
+        <material state="solid" name="G4_Al">
+            <D value="2.699" unit="g/cm3"/>
+            <fraction n="1.0" ref="Al"/>
+        </material>
+        <material state="solid" name="G4_Si">
+            <D value="2.33" unit="g/cm3"/>
+            <fraction n="1.0" ref="Si"/>
+        </material>
+        <material state="solid" name="G4_P">
+            <D value="2.2" unit="g/cm3"/>
+            <fraction n="1.0" ref="P"/>
+        </material>
+        <material state="solid" name="G4_S">
+            <D value="2.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="S"/>
+        </material>
+        <material state="gas" name="G4_Cl">
+            <D value="0.00299473" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cl"/>
+        </material>
+        <material state="gas" name="G4_Ar">
+            <D value="0.00166201" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ar"/>
+        </material>
+        <material state="solid" name="G4_K">
+            <D value="0.862" unit="g/cm3"/>
+            <fraction n="1.0" ref="K"/>
+        </material>
+        <material state="solid" name="G4_Ca">
+            <D value="1.55" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_Sc">
+            <D value="2.989" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sc"/>
+        </material>
+        <material state="solid" name="G4_Ti">
+            <D value="4.54" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ti"/>
+        </material>
+        <material state="solid" name="G4_V">
+            <D value="6.11" unit="g/cm3"/>
+            <fraction n="1.0" ref="V"/>
+        </material>
+        <material state="solid" name="G4_Cr">
+            <D value="7.18" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cr"/>
+        </material>
+        <material state="solid" name="G4_Mn">
+            <D value="7.44" unit="g/cm3"/>
+            <fraction n="1.0" ref="Mn"/>
+        </material>
+        <material state="solid" name="G4_Fe">
+            <D value="7.874" unit="g/cm3"/>
+            <fraction n="1.0" ref="Fe"/>
+        </material>
+        <material state="solid" name="G4_Co">
+            <D value="8.9" unit="g/cm3"/>
+            <fraction n="1.0" ref="Co"/>
+        </material>
+        <material state="solid" name="G4_Ni">
+            <D value="8.902" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ni"/>
+        </material>
+        <material state="solid" name="G4_Cu">
+            <D value="8.96" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cu"/>
+        </material>
+        <material state="solid" name="G4_Zn">
+            <D value="7.133" unit="g/cm3"/>
+            <fraction n="1.0" ref="Zn"/>
+        </material>
+        <material state="solid" name="G4_Ga">
+            <D value="5.904" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ga"/>
+        </material>
+        <material state="solid" name="G4_Ge">
+            <D value="5.323" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ge"/>
+        </material>
+        <material state="solid" name="G4_As">
+            <D value="5.73" unit="g/cm3"/>
+            <fraction n="1.0" ref="As"/>
+        </material>
+        <material state="solid" name="G4_Se">
+            <D value="4.5" unit="g/cm3"/>
+            <fraction n="1.0" ref="Se"/>
+        </material>
+        <material state="gas" name="G4_Br">
+            <D value="0.0070721" unit="g/cm3"/>
+            <fraction n="1.0" ref="Br"/>
+        </material>
+        <material state="gas" name="G4_Kr">
+            <D value="0.00347832" unit="g/cm3"/>
+            <fraction n="1.0" ref="Kr"/>
+        </material>
+        <material state="solid" name="G4_Rb">
+            <D value="1.532" unit="g/cm3"/>
+            <fraction n="1.0" ref="Rb"/>
+        </material>
+        <material state="solid" name="G4_Sr">
+            <D value="2.54" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sr"/>
+        </material>
+        <material state="solid" name="G4_Y">
+            <D value="4.469" unit="g/cm3"/>
+            <fraction n="1.0" ref="Y"/>
+        </material>
+        <material state="solid" name="G4_Zr">
+            <D value="6.506" unit="g/cm3"/>
+            <fraction n="1.0" ref="Zr"/>
+        </material>
+        <material state="solid" name="G4_Nb">
+            <D value="8.57" unit="g/cm3"/>
+            <fraction n="1.0" ref="Nb"/>
+        </material>
+        <material state="solid" name="G4_Mo">
+            <D value="10.22" unit="g/cm3"/>
+            <fraction n="1.0" ref="Mo"/>
+        </material>
+        <material state="solid" name="G4_Tc">
+            <D value="11.5" unit="g/cm3"/>
+            <fraction n="1.0" ref="Tc"/>
+        </material>
+        <material state="solid" name="G4_Ru">
+            <D value="12.41" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ru"/>
+        </material>
+        <material state="solid" name="G4_Rh">
+            <D value="12.41" unit="g/cm3"/>
+            <fraction n="1.0" ref="Rh"/>
+        </material>
+        <material state="solid" name="G4_Pd">
+            <D value="12.02" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pd"/>
+        </material>
+        <material state="solid" name="G4_Ag">
+            <D value="10.5" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ag"/>
+        </material>
+        <material state="solid" name="G4_Cd">
+            <D value="8.65" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cd"/>
+        </material>
+        <material state="solid" name="G4_In">
+            <D value="7.31" unit="g/cm3"/>
+            <fraction n="1.0" ref="In"/>
+        </material>
+        <material state="solid" name="G4_Sn">
+            <D value="7.31" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sn"/>
+        </material>
+        <material state="solid" name="G4_Sb">
+            <D value="6.691" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sb"/>
+        </material>
+        <material state="solid" name="G4_Te">
+            <D value="6.24" unit="g/cm3"/>
+            <fraction n="1.0" ref="Te"/>
+        </material>
+        <material state="solid" name="G4_I">
+            <D value="4.93" unit="g/cm3"/>
+            <fraction n="1.0" ref="I"/>
+        </material>
+        <material state="gas" name="G4_Xe">
+            <D value="0.00548536" unit="g/cm3"/>
+            <fraction n="1.0" ref="Xe"/>
+        </material>
+        <material state="solid" name="G4_Cs">
+            <D value="1.873" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cs"/>
+        </material>
+        <material state="solid" name="G4_Ba">
+            <D value="3.5" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ba"/>
+        </material>
+        <material state="solid" name="G4_La">
+            <D value="6.154" unit="g/cm3"/>
+            <fraction n="1.0" ref="La"/>
+        </material>
+        <material state="solid" name="G4_Ce">
+            <D value="6.657" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ce"/>
+        </material>
+        <material state="solid" name="G4_Pr">
+            <D value="6.71" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pr"/>
+        </material>
+        <material state="solid" name="G4_Nd">
+            <D value="6.9" unit="g/cm3"/>
+            <fraction n="1.0" ref="Nd"/>
+        </material>
+        <material state="solid" name="G4_Pm">
+            <D value="7.22" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pm"/>
+        </material>
+        <material state="solid" name="G4_Sm">
+            <D value="7.46" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sm"/>
+        </material>
+        <material state="solid" name="G4_Eu">
+            <D value="5.243" unit="g/cm3"/>
+            <fraction n="1.0" ref="Eu"/>
+        </material>
+        <material state="solid" name="G4_Gd">
+            <D value="7.9004" unit="g/cm3"/>
+            <fraction n="1.0" ref="Gd"/>
+        </material>
+        <material state="solid" name="G4_Tb">
+            <D value="8.229" unit="g/cm3"/>
+            <fraction n="1.0" ref="Tb"/>
+        </material>
+        <material state="solid" name="G4_Dy">
+            <D value="8.55" unit="g/cm3"/>
+            <fraction n="1.0" ref="Dy"/>
+        </material>
+        <material state="solid" name="G4_Ho">
+            <D value="8.795" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ho"/>
+        </material>
+        <material state="solid" name="G4_Er">
+            <D value="9.066" unit="g/cm3"/>
+            <fraction n="1.0" ref="Er"/>
+        </material>
+        <material state="solid" name="G4_Tm">
+            <D value="9.321" unit="g/cm3"/>
+            <fraction n="1.0" ref="Tm"/>
+        </material>
+        <material state="solid" name="G4_Yb">
+            <D value="6.73" unit="g/cm3"/>
+            <fraction n="1.0" ref="Yb"/>
+        </material>
+        <material state="solid" name="G4_Lu">
+            <D value="9.84" unit="g/cm3"/>
+            <fraction n="1.0" ref="Lu"/>
+        </material>
+        <material state="solid" name="G4_Hf">
+            <D value="13.31" unit="g/cm3"/>
+            <fraction n="1.0" ref="Hf"/>
+        </material>
+        <material state="solid" name="G4_Ta">
+            <D value="16.654" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ta"/>
+        </material>
+        <material state="solid" name="G4_W">
+            <D value="19.3" unit="g/cm3"/>
+            <fraction n="1.0" ref="W"/>
+        </material>
+        <material state="solid" name="G4_Re">
+            <D value="21.02" unit="g/cm3"/>
+            <fraction n="1.0" ref="Re"/>
+        </material>
+        <material state="solid" name="G4_Os">
+            <D value="22.57" unit="g/cm3"/>
+            <fraction n="1.0" ref="Os"/>
+        </material>
+        <material state="solid" name="G4_Ir">
+            <D value="22.42" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ir"/>
+        </material>
+        <material state="solid" name="G4_Pt">
+            <D value="21.45" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pt"/>
+        </material>
+        <material state="solid" name="G4_Au">
+            <D value="19.32" unit="g/cm3"/>
+            <fraction n="1.0" ref="Au"/>
+        </material>
+        <material state="solid" name="G4_Hg">
+            <D value="13.546" unit="g/cm3"/>
+            <fraction n="1.0" ref="Hg"/>
+        </material>
+        <material state="solid" name="G4_Tl">
+            <D value="11.72" unit="g/cm3"/>
+            <fraction n="1.0" ref="Tl"/>
+        </material>
+        <material state="solid" name="G4_Pb">
+            <D value="11.35" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_Bi">
+            <D value="9.747" unit="g/cm3"/>
+            <fraction n="1.0" ref="Bi"/>
+        </material>
+        <material state="solid" name="G4_Po">
+            <D value="9.32" unit="g/cm3"/>
+            <fraction n="1.0" ref="Po"/>
+        </material>
+        <material state="solid" name="G4_At">
+            <D value="9.32" unit="g/cm3"/>
+            <fraction n="1.0" ref="At"/>
+        </material>
+        <material state="gas" name="G4_Rn">
+            <D value="0.00900662" unit="g/cm3"/>
+            <fraction n="1.0" ref="Rn"/>
+        </material>
+        <material state="solid" name="G4_Fr">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="Fr"/>
+        </material>
+        <material state="solid" name="G4_Ra">
+            <D value="5.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ra"/>
+        </material>
+        <material state="solid" name="G4_Ac">
+            <D value="10.07" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ac"/>
+        </material>
+        <material state="solid" name="G4_Th">
+            <D value="11.72" unit="g/cm3"/>
+            <fraction n="1.0" ref="Th"/>
+        </material>
+        <material state="solid" name="G4_Pa">
+            <D value="15.37" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pa"/>
+        </material>
+        <material state="solid" name="G4_U">
+            <D value="18.95" unit="g/cm3"/>
+            <fraction n="1.0" ref="U"/>
+        </material>
+        <material state="solid" name="G4_Np">
+            <D value="20.25" unit="g/cm3"/>
+            <fraction n="1.0" ref="Np"/>
+        </material>
+        <material state="solid" name="G4_Pu">
+            <D value="19.84" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pu"/>
+        </material>
+        <material state="solid" name="G4_Am">
+            <D value="13.67" unit="g/cm3"/>
+            <fraction n="1.0" ref="Am"/>
+        </material>
+        <material state="solid" name="G4_Cm">
+            <D value="13.51" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cm"/>
+        </material>
+        <material state="solid" name="G4_Bk">
+            <D value="14.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="Bk"/>
+        </material>
+        <material state="solid" name="G4_Cf">
+            <D value="10.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cf"/>
+        </material>
+        <material state="solid" name="G4_A-150_TISSUE">
+            <D value="1.127" unit="g/cm3"/>
+            <fraction n="0.101327" ref="H"/>
+            <fraction n="0.7755" ref="C"/>
+            <fraction n="0.035057" ref="N"/>
+            <fraction n="0.052316" ref="O"/>
+            <fraction n="0.017422" ref="F"/>
+            <fraction n="0.018378" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_ACETONE">
+            <D value="0.7899" unit="g/cm3"/>
+            <fraction n="0.620397" ref="C"/>
+            <fraction n="0.104127" ref="H"/>
+            <fraction n="0.275475" ref="O"/>
+        </material>
+        <material state="gas" name="G4_ACETYLENE">
+            <D value="0.0010967" unit="g/cm3"/>
+            <fraction n="0.922577" ref="C"/>
+            <fraction n="0.077423" ref="H"/>
+        </material>
+        <material state="solid" name="G4_ADENINE">
+            <D value="1.6" unit="g/cm3"/>
+            <fraction n="0.444423" ref="C"/>
+            <fraction n="0.037296" ref="H"/>
+            <fraction n="0.518281" ref="N"/>
+        </material>
+        <material state="solid" name="G4_ADIPOSE_TISSUE_ICRP">
+            <D value="0.95" unit="g/cm3"/>
+            <fraction n="0.114" ref="H"/>
+            <fraction n="0.598" ref="C"/>
+            <fraction n="0.007" ref="N"/>
+            <fraction n="0.278" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="S"/>
+            <fraction n="0.001" ref="Cl"/>
+        </material>
+        <material state="gas" name="G4_AIR">
+            <D value="0.00120479" unit="g/cm3"/>
+            <fraction n="1.24E-4" ref="C"/>
+            <fraction n="0.755268" ref="N"/>
+            <fraction n="0.231781" ref="O"/>
+            <fraction n="0.012827" ref="Ar"/>
+        </material>
+        <material state="solid" name="G4_ALANINE">
+            <D value="1.42" unit="g/cm3"/>
+            <fraction n="0.404432" ref="C"/>
+            <fraction n="0.079193" ref="H"/>
+            <fraction n="0.157215" ref="N"/>
+            <fraction n="0.35916" ref="O"/>
+        </material>
+        <material state="solid" name="G4_ALUMINUM_OXIDE">
+            <D value="3.97" unit="g/cm3"/>
+            <fraction n="0.52925" ref="Al"/>
+            <fraction n="0.47075" ref="O"/>
+        </material>
+        <material state="solid" name="G4_AMBER">
+            <D value="1.1" unit="g/cm3"/>
+            <fraction n="0.10593" ref="H"/>
+            <fraction n="0.788974" ref="C"/>
+            <fraction n="0.105096" ref="O"/>
+        </material>
+        <material state="gas" name="G4_AMMONIA">
+            <D value="8.26019E-4" unit="g/cm3"/>
+            <fraction n="0.822448" ref="N"/>
+            <fraction n="0.177552" ref="H"/>
+        </material>
+        <material state="solid" name="G4_ANILINE">
+            <D value="1.0235" unit="g/cm3"/>
+            <fraction n="0.773831" ref="C"/>
+            <fraction n="0.075763" ref="H"/>
+            <fraction n="0.150405" ref="N"/>
+        </material>
+        <material state="solid" name="G4_ANTHRACENE">
+            <D value="1.283" unit="g/cm3"/>
+            <fraction n="0.943447" ref="C"/>
+            <fraction n="0.056553" ref="H"/>
+        </material>
+        <material state="solid" name="G4_B-100_BONE">
+            <D value="1.45" unit="g/cm3"/>
+            <fraction n="0.065471" ref="H"/>
+            <fraction n="0.536944" ref="C"/>
+            <fraction n="0.0215" ref="N"/>
+            <fraction n="0.032085" ref="O"/>
+            <fraction n="0.167411" ref="F"/>
+            <fraction n="0.176589" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_BAKELITE">
+            <D value="1.25" unit="g/cm3"/>
+            <fraction n="0.057441" ref="H"/>
+            <fraction n="0.774591" ref="C"/>
+            <fraction n="0.167968" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BARIUM_FLUORIDE">
+            <D value="4.89" unit="g/cm3"/>
+            <fraction n="0.783276" ref="Ba"/>
+            <fraction n="0.216724" ref="F"/>
+        </material>
+        <material state="solid" name="G4_BARIUM_SULFATE">
+            <D value="4.5" unit="g/cm3"/>
+            <fraction n="0.588399" ref="Ba"/>
+            <fraction n="0.137393" ref="S"/>
+            <fraction n="0.274208" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BENZENE">
+            <D value="0.87865" unit="g/cm3"/>
+            <fraction n="0.922577" ref="C"/>
+            <fraction n="0.077423" ref="H"/>
+        </material>
+        <material state="solid" name="G4_BERYLLIUM_OXIDE">
+            <D value="3.01" unit="g/cm3"/>
+            <fraction n="0.36032" ref="Be"/>
+            <fraction n="0.63968" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BGO">
+            <D value="7.13" unit="g/cm3"/>
+            <fraction n="0.671017" ref="Bi"/>
+            <fraction n="0.174865" ref="Ge"/>
+            <fraction n="0.154118" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BLOOD_ICRP">
+            <D value="1.06" unit="g/cm3"/>
+            <fraction n="0.102" ref="H"/>
+            <fraction n="0.11" ref="C"/>
+            <fraction n="0.033" ref="N"/>
+            <fraction n="0.745" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+            <fraction n="0.001" ref="Fe"/>
+        </material>
+        <material state="solid" name="G4_BONE_COMPACT_ICRU">
+            <D value="1.85" unit="g/cm3"/>
+            <fraction n="0.064" ref="H"/>
+            <fraction n="0.278" ref="C"/>
+            <fraction n="0.027" ref="N"/>
+            <fraction n="0.41" ref="O"/>
+            <fraction n="0.002" ref="Mg"/>
+            <fraction n="0.07" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.147" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_BONE_CORTICAL_ICRP">
+            <D value="1.92" unit="g/cm3"/>
+            <fraction n="0.034" ref="H"/>
+            <fraction n="0.155" ref="C"/>
+            <fraction n="0.042" ref="N"/>
+            <fraction n="0.435" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.002" ref="Mg"/>
+            <fraction n="0.103" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.225" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_BORON_CARBIDE">
+            <D value="2.52" unit="g/cm3"/>
+            <fraction n="0.78263" ref="B"/>
+            <fraction n="0.21737" ref="C"/>
+        </material>
+        <material state="solid" name="G4_BORON_OXIDE">
+            <D value="1.812" unit="g/cm3"/>
+            <fraction n="0.310571" ref="B"/>
+            <fraction n="0.689429" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BRAIN_ICRP">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.107" ref="H"/>
+            <fraction n="0.145" ref="C"/>
+            <fraction n="0.022" ref="N"/>
+            <fraction n="0.712" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.004" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.003" ref="K"/>
+        </material>
+        <material state="solid" name="G4_BREAST_ICRP">
+            <D value="1.02" unit="g/cm3"/>
+            <fraction n="0.106" ref="H"/>
+            <fraction n="0.332" ref="C"/>
+            <fraction n="0.03" ref="N"/>
+            <fraction n="0.527" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.001" ref="Cl"/>
+        </material>
+        <material state="gas" name="G4_BUTANE">
+            <D value="0.00249343" unit="g/cm3"/>
+            <fraction n="0.826583" ref="C"/>
+            <fraction n="0.173417" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-BUTYL_ALCOHOL">
+            <D value="0.8098" unit="g/cm3"/>
+            <fraction n="0.648163" ref="C"/>
+            <fraction n="0.135984" ref="H"/>
+            <fraction n="0.215853" ref="O"/>
+        </material>
+        <material state="solid" name="G4_C-552">
+            <D value="1.76" unit="g/cm3"/>
+            <fraction n="0.02468" ref="H"/>
+            <fraction n="0.501611" ref="C"/>
+            <fraction n="0.004527" ref="O"/>
+            <fraction n="0.465209" ref="F"/>
+            <fraction n="0.003973" ref="Si"/>
+        </material>
+        <material state="solid" name="G4_CADMIUM_TELLURIDE">
+            <D value="6.2" unit="g/cm3"/>
+            <fraction n="0.468353" ref="Cd"/>
+            <fraction n="0.531647" ref="Te"/>
+        </material>
+        <material state="solid" name="G4_CADMIUM_TUNGSTATE">
+            <D value="7.9" unit="g/cm3"/>
+            <fraction n="0.312037" ref="Cd"/>
+            <fraction n="0.510316" ref="W"/>
+            <fraction n="0.177647" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_CARBONATE">
+            <D value="2.8" unit="g/cm3"/>
+            <fraction n="0.400432" ref="Ca"/>
+            <fraction n="0.120003" ref="C"/>
+            <fraction n="0.479565" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_FLUORIDE">
+            <D value="3.18" unit="g/cm3"/>
+            <fraction n="0.513328" ref="Ca"/>
+            <fraction n="0.486672" ref="F"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_OXIDE">
+            <D value="3.3" unit="g/cm3"/>
+            <fraction n="0.714691" ref="Ca"/>
+            <fraction n="0.285309" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_SULFATE">
+            <D value="2.96" unit="g/cm3"/>
+            <fraction n="0.294385" ref="Ca"/>
+            <fraction n="0.235535" ref="S"/>
+            <fraction n="0.47008" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_TUNGSTATE">
+            <D value="6.062" unit="g/cm3"/>
+            <fraction n="0.1392" ref="Ca"/>
+            <fraction n="0.638522" ref="W"/>
+            <fraction n="0.222278" ref="O"/>
+        </material>
+        <material state="gas" name="G4_CARBON_DIOXIDE">
+            <D value="0.00184212" unit="g/cm3"/>
+            <fraction n="0.272912" ref="C"/>
+            <fraction n="0.727088" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CARBON_TETRACHLORIDE">
+            <D value="1.594" unit="g/cm3"/>
+            <fraction n="0.078083" ref="C"/>
+            <fraction n="0.921917" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_CELLULOSE_CELLOPHANE">
+            <D value="1.42" unit="g/cm3"/>
+            <fraction n="0.444456" ref="C"/>
+            <fraction n="0.062165" ref="H"/>
+            <fraction n="0.49338" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CELLULOSE_BUTYRATE">
+            <D value="1.2" unit="g/cm3"/>
+            <fraction n="0.067125" ref="H"/>
+            <fraction n="0.545403" ref="C"/>
+            <fraction n="0.387472" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CELLULOSE_NITRATE">
+            <D value="1.49" unit="g/cm3"/>
+            <fraction n="0.029216" ref="H"/>
+            <fraction n="0.271296" ref="C"/>
+            <fraction n="0.121276" ref="N"/>
+            <fraction n="0.578212" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CERIC_SULFATE">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.107596" ref="H"/>
+            <fraction n="8.0E-4" ref="N"/>
+            <fraction n="0.874976" ref="O"/>
+            <fraction n="0.014627" ref="S"/>
+            <fraction n="0.002001" ref="Ce"/>
+        </material>
+        <material state="solid" name="G4_CESIUM_FLUORIDE">
+            <D value="4.115" unit="g/cm3"/>
+            <fraction n="0.874931" ref="Cs"/>
+            <fraction n="0.125069" ref="F"/>
+        </material>
+        <material state="solid" name="G4_CESIUM_IODIDE">
+            <D value="4.51" unit="g/cm3"/>
+            <fraction n="0.511549" ref="Cs"/>
+            <fraction n="0.488451" ref="I"/>
+        </material>
+        <material state="solid" name="G4_CHLOROBENZENE">
+            <D value="1.1058" unit="g/cm3"/>
+            <fraction n="0.64025" ref="C"/>
+            <fraction n="0.044775" ref="H"/>
+            <fraction n="0.314975" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_CHLOROFORM">
+            <D value="1.4832" unit="g/cm3"/>
+            <fraction n="0.100612" ref="C"/>
+            <fraction n="0.008443" ref="H"/>
+            <fraction n="0.890944" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_CONCRETE">
+            <D value="2.3" unit="g/cm3"/>
+            <fraction n="0.01" ref="H"/>
+            <fraction n="0.001" ref="C"/>
+            <fraction n="0.529107" ref="O"/>
+            <fraction n="0.016" ref="Na"/>
+            <fraction n="0.002" ref="Mg"/>
+            <fraction n="0.033872" ref="Al"/>
+            <fraction n="0.337021" ref="Si"/>
+            <fraction n="0.013" ref="K"/>
+            <fraction n="0.044" ref="Ca"/>
+            <fraction n="0.014" ref="Fe"/>
+        </material>
+        <material state="solid" name="G4_CYCLOHEXANE">
+            <D value="0.779" unit="g/cm3"/>
+            <fraction n="0.856282" ref="C"/>
+            <fraction n="0.143718" ref="H"/>
+        </material>
+        <material state="solid" name="G4_1,2-DICHLOROBENZENE">
+            <D value="1.3048" unit="g/cm3"/>
+            <fraction n="0.49023" ref="C"/>
+            <fraction n="0.027427" ref="H"/>
+            <fraction n="0.482344" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_DICHLORODIETHYL_ETHER">
+            <D value="1.2199" unit="g/cm3"/>
+            <fraction n="0.335939" ref="C"/>
+            <fraction n="0.056384" ref="H"/>
+            <fraction n="0.111875" ref="O"/>
+            <fraction n="0.495802" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_1,2-DICHLOROETHANE">
+            <D value="1.2351" unit="g/cm3"/>
+            <fraction n="0.242743" ref="C"/>
+            <fraction n="0.040742" ref="H"/>
+            <fraction n="0.716515" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_DIETHYL_ETHER">
+            <D value="0.71378" unit="g/cm3"/>
+            <fraction n="0.648163" ref="C"/>
+            <fraction n="0.135984" ref="H"/>
+            <fraction n="0.215853" ref="O"/>
+        </material>
+        <material state="solid" name="G4_N,N-DIMETHYL_FORMAMIDE">
+            <D value="0.9487" unit="g/cm3"/>
+            <fraction n="0.492957" ref="C"/>
+            <fraction n="0.096528" ref="H"/>
+            <fraction n="0.191627" ref="N"/>
+            <fraction n="0.218888" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DIMETHYL_SULFOXIDE">
+            <D value="1.1014" unit="g/cm3"/>
+            <fraction n="0.307437" ref="C"/>
+            <fraction n="0.0774" ref="H"/>
+            <fraction n="0.204767" ref="O"/>
+            <fraction n="0.410396" ref="S"/>
+        </material>
+        <material state="gas" name="G4_ETHANE">
+            <D value="0.00125324" unit="g/cm3"/>
+            <fraction n="0.798875" ref="C"/>
+            <fraction n="0.201125" ref="H"/>
+        </material>
+        <material state="solid" name="G4_ETHYL_ALCOHOL">
+            <D value="0.7893" unit="g/cm3"/>
+            <fraction n="0.521429" ref="C"/>
+            <fraction n="0.131275" ref="H"/>
+            <fraction n="0.347296" ref="O"/>
+        </material>
+        <material state="solid" name="G4_ETHYL_CELLULOSE">
+            <D value="1.13" unit="g/cm3"/>
+            <fraction n="0.090027" ref="H"/>
+            <fraction n="0.585182" ref="C"/>
+            <fraction n="0.324791" ref="O"/>
+        </material>
+        <material state="gas" name="G4_ETHYLENE">
+            <D value="0.00117497" unit="g/cm3"/>
+            <fraction n="0.856282" ref="C"/>
+            <fraction n="0.143718" ref="H"/>
+        </material>
+        <material state="solid" name="G4_EYE_LENS_ICRP">
+            <D value="1.07" unit="g/cm3"/>
+            <fraction n="0.096" ref="H"/>
+            <fraction n="0.195" ref="C"/>
+            <fraction n="0.057" ref="N"/>
+            <fraction n="0.646" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.001" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_FERRIC_OXIDE">
+            <D value="5.2" unit="g/cm3"/>
+            <fraction n="0.699426" ref="Fe"/>
+            <fraction n="0.300574" ref="O"/>
+        </material>
+        <material state="solid" name="G4_FERROBORIDE">
+            <D value="7.15" unit="g/cm3"/>
+            <fraction n="0.837809" ref="Fe"/>
+            <fraction n="0.162191" ref="B"/>
+        </material>
+        <material state="solid" name="G4_FERROUS_OXIDE">
+            <D value="5.7" unit="g/cm3"/>
+            <fraction n="0.777305" ref="Fe"/>
+            <fraction n="0.222695" ref="O"/>
+        </material>
+        <material state="solid" name="G4_FERROUS_SULFATE">
+            <D value="1.024" unit="g/cm3"/>
+            <fraction n="0.108259" ref="H"/>
+            <fraction n="2.7E-5" ref="N"/>
+            <fraction n="0.878636" ref="O"/>
+            <fraction n="2.2E-5" ref="Na"/>
+            <fraction n="0.012968" ref="S"/>
+            <fraction n="3.4E-5" ref="Cl"/>
+            <fraction n="5.4E-5" ref="Fe"/>
+        </material>
+        <material state="solid" name="G4_FREON-12">
+            <D value="1.12" unit="g/cm3"/>
+            <fraction n="0.099335" ref="C"/>
+            <fraction n="0.314247" ref="F"/>
+            <fraction n="0.586418" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_FREON-12B2">
+            <D value="1.8" unit="g/cm3"/>
+            <fraction n="0.057245" ref="C"/>
+            <fraction n="0.181096" ref="F"/>
+            <fraction n="0.761659" ref="Br"/>
+        </material>
+        <material state="solid" name="G4_FREON-13">
+            <D value="0.95" unit="g/cm3"/>
+            <fraction n="0.114983" ref="C"/>
+            <fraction n="0.545621" ref="F"/>
+            <fraction n="0.339396" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_FREON-13B1">
+            <D value="1.5" unit="g/cm3"/>
+            <fraction n="0.080658" ref="C"/>
+            <fraction n="0.382751" ref="F"/>
+            <fraction n="0.536591" ref="Br"/>
+        </material>
+        <material state="solid" name="G4_FREON-13I1">
+            <D value="1.8" unit="g/cm3"/>
+            <fraction n="0.061309" ref="C"/>
+            <fraction n="0.290924" ref="F"/>
+            <fraction n="0.647767" ref="I"/>
+        </material>
+        <material state="solid" name="G4_GADOLINIUM_OXYSULFIDE">
+            <D value="7.44" unit="g/cm3"/>
+            <fraction n="0.830771" ref="Gd"/>
+            <fraction n="0.084526" ref="O"/>
+            <fraction n="0.084703" ref="S"/>
+        </material>
+        <material state="solid" name="G4_GALLIUM_ARSENIDE">
+            <D value="5.31" unit="g/cm3"/>
+            <fraction n="0.48203" ref="Ga"/>
+            <fraction n="0.51797" ref="As"/>
+        </material>
+        <material state="solid" name="G4_GEL_PHOTO_EMULSION">
+            <D value="1.2914" unit="g/cm3"/>
+            <fraction n="0.08118" ref="H"/>
+            <fraction n="0.41606" ref="C"/>
+            <fraction n="0.11124" ref="N"/>
+            <fraction n="0.38064" ref="O"/>
+            <fraction n="0.01088" ref="S"/>
+        </material>
+        <material state="solid" name="G4_Pyrex_Glass">
+            <D value="2.23" unit="g/cm3"/>
+            <fraction n="0.040064" ref="B"/>
+            <fraction n="0.539561" ref="O"/>
+            <fraction n="0.028191" ref="Na"/>
+            <fraction n="0.011644" ref="Al"/>
+            <fraction n="0.377219" ref="Si"/>
+            <fraction n="0.003321" ref="K"/>
+        </material>
+        <material state="solid" name="G4_GLASS_LEAD">
+            <D value="6.22" unit="g/cm3"/>
+            <fraction n="0.156453" ref="O"/>
+            <fraction n="0.080866" ref="Si"/>
+            <fraction n="0.008092" ref="Ti"/>
+            <fraction n="0.002651" ref="As"/>
+            <fraction n="0.751938" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_GLASS_PLATE">
+            <D value="2.4" unit="g/cm3"/>
+            <fraction n="0.4598" ref="O"/>
+            <fraction n="0.096441" ref="Na"/>
+            <fraction n="0.336553" ref="Si"/>
+            <fraction n="0.107205" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_GLUTAMINE">
+            <D value="1.46" unit="g/cm3"/>
+            <fraction n="0.410919" ref="C"/>
+            <fraction n="0.068969" ref="H"/>
+            <fraction n="0.191683" ref="N"/>
+            <fraction n="0.328429" ref="O"/>
+        </material>
+        <material state="solid" name="G4_GLYCEROL">
+            <D value="1.2613" unit="g/cm3"/>
+            <fraction n="0.391255" ref="C"/>
+            <fraction n="0.087558" ref="H"/>
+            <fraction n="0.521187" ref="O"/>
+        </material>
+        <material state="solid" name="G4_GUANINE">
+            <D value="2.2" unit="g/cm3"/>
+            <fraction n="0.397373" ref="C"/>
+            <fraction n="0.033348" ref="H"/>
+            <fraction n="0.463412" ref="N"/>
+            <fraction n="0.105867" ref="O"/>
+        </material>
+        <material state="solid" name="G4_GYPSUM">
+            <D value="2.32" unit="g/cm3"/>
+            <fraction n="0.232779" ref="Ca"/>
+            <fraction n="0.186244" ref="S"/>
+            <fraction n="0.55756" ref="O"/>
+            <fraction n="0.023417" ref="H"/>
+        </material>
+        <material state="solid" name="G4_HEART_ICRP">
+            <D value="1.055" unit="g/cm3"/>
+            <fraction n="0.103" ref="H"/>
+            <fraction n="0.121" ref="C"/>
+            <fraction n="0.032" ref="N"/>
+            <fraction n="0.734" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+        </material>
+        <material state="solid" name="G4_N-HEPTANE">
+            <D value="0.68376" unit="g/cm3"/>
+            <fraction n="0.839055" ref="C"/>
+            <fraction n="0.160945" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-HEXANE">
+            <D value="0.6603" unit="g/cm3"/>
+            <fraction n="0.836251" ref="C"/>
+            <fraction n="0.163749" ref="H"/>
+        </material>
+        <material state="solid" name="G4_KAPTON">
+            <D value="1.42" unit="g/cm3"/>
+            <fraction n="0.691128" ref="C"/>
+            <fraction n="0.026363" ref="H"/>
+            <fraction n="0.073271" ref="N"/>
+            <fraction n="0.209237" ref="O"/>
+        </material>
+        <material state="solid" name="G4_KIDNEY_ICRP">
+            <D value="1.05" unit="g/cm3"/>
+            <fraction n="0.103" ref="H"/>
+            <fraction n="0.132" ref="C"/>
+            <fraction n="0.03" ref="N"/>
+            <fraction n="0.724" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.002" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.002" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+            <fraction n="0.001" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_LANTHANUM_OXYBROMIDE">
+            <D value="6.28" unit="g/cm3"/>
+            <fraction n="0.591569" ref="La"/>
+            <fraction n="0.340293" ref="Br"/>
+            <fraction n="0.068138" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LANTHANUM_OXYSULFIDE">
+            <D value="5.86" unit="g/cm3"/>
+            <fraction n="0.812607" ref="La"/>
+            <fraction n="0.093598" ref="O"/>
+            <fraction n="0.093795" ref="S"/>
+        </material>
+        <material state="solid" name="G4_LEAD_OXIDE">
+            <D value="9.53" unit="g/cm3"/>
+            <fraction n="0.071682" ref="O"/>
+            <fraction n="0.928318" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_AMIDE">
+            <D value="1.178" unit="g/cm3"/>
+            <fraction n="0.302231" ref="Li"/>
+            <fraction n="0.60998" ref="N"/>
+            <fraction n="0.087789" ref="H"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_CARBONATE">
+            <D value="2.11" unit="g/cm3"/>
+            <fraction n="0.18785" ref="Li"/>
+            <fraction n="0.162551" ref="C"/>
+            <fraction n="0.649599" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_FLUORIDE">
+            <D value="2.635" unit="g/cm3"/>
+            <fraction n="0.267558" ref="Li"/>
+            <fraction n="0.732442" ref="F"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_HYDRIDE">
+            <D value="0.82" unit="g/cm3"/>
+            <fraction n="0.873183" ref="Li"/>
+            <fraction n="0.126817" ref="H"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_IODIDE">
+            <D value="3.494" unit="g/cm3"/>
+            <fraction n="0.051852" ref="Li"/>
+            <fraction n="0.948148" ref="I"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_OXIDE">
+            <D value="2.013" unit="g/cm3"/>
+            <fraction n="0.464535" ref="Li"/>
+            <fraction n="0.535465" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_TETRABORATE">
+            <D value="2.44" unit="g/cm3"/>
+            <fraction n="0.082072" ref="Li"/>
+            <fraction n="0.255701" ref="B"/>
+            <fraction n="0.662227" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LIVER_ICRP">
+            <D value="1.065" unit="g/cm3"/>
+            <fraction n="0.102" ref="H"/>
+            <fraction n="0.139" ref="C"/>
+            <fraction n="0.03" ref="N"/>
+            <fraction n="0.716" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.003" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.002" ref="Cl"/>
+            <fraction n="0.003" ref="K"/>
+        </material>
+        <material state="solid" name="G4_LUNG_ICRP">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.105" ref="H"/>
+            <fraction n="0.083" ref="C"/>
+            <fraction n="0.023" ref="N"/>
+            <fraction n="0.779" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+        </material>
+        <material state="solid" name="G4_M3_WAX">
+            <D value="1.05" unit="g/cm3"/>
+            <fraction n="0.114318" ref="H"/>
+            <fraction n="0.655824" ref="C"/>
+            <fraction n="0.092183" ref="O"/>
+            <fraction n="0.134792" ref="Mg"/>
+            <fraction n="0.002883" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_MAGNESIUM_CARBONATE">
+            <D value="2.958" unit="g/cm3"/>
+            <fraction n="0.288268" ref="Mg"/>
+            <fraction n="0.142453" ref="C"/>
+            <fraction n="0.569279" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MAGNESIUM_FLUORIDE">
+            <D value="3.0" unit="g/cm3"/>
+            <fraction n="0.390117" ref="Mg"/>
+            <fraction n="0.609883" ref="F"/>
+        </material>
+        <material state="solid" name="G4_MAGNESIUM_OXIDE">
+            <D value="3.58" unit="g/cm3"/>
+            <fraction n="0.603036" ref="Mg"/>
+            <fraction n="0.396964" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MAGNESIUM_TETRABORATE">
+            <D value="2.53" unit="g/cm3"/>
+            <fraction n="0.13537" ref="Mg"/>
+            <fraction n="0.240854" ref="B"/>
+            <fraction n="0.623776" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MERCURIC_IODIDE">
+            <D value="6.36" unit="g/cm3"/>
+            <fraction n="0.441452" ref="Hg"/>
+            <fraction n="0.558548" ref="I"/>
+        </material>
+        <material state="solid" name="G4_SILICUM_OXIDE">
+            <D value="2.65" unit="g/cm3"/>
+            <fraction n="0.467" ref="Si"/>
+            <fraction n="0.532" ref="O"/>
+        </material>
+        <material state="gas" name="G4_METHANE">
+            <D value="6.67151E-4" unit="g/cm3"/>
+            <fraction n="0.748682" ref="C"/>
+            <fraction n="0.251318" ref="H"/>
+        </material>
+        <material state="solid" name="G4_METHANOL">
+            <D value="0.7914" unit="g/cm3"/>
+            <fraction n="0.374845" ref="C"/>
+            <fraction n="0.125828" ref="H"/>
+            <fraction n="0.499327" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MIX_D_WAX">
+            <D value="0.99" unit="g/cm3"/>
+            <fraction n="0.13404" ref="H"/>
+            <fraction n="0.77796" ref="C"/>
+            <fraction n="0.03502" ref="O"/>
+            <fraction n="0.038594" ref="Mg"/>
+            <fraction n="0.014386" ref="Ti"/>
+        </material>
+        <material state="solid" name="G4_MS20_TISSUE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.081192" ref="H"/>
+            <fraction n="0.583442" ref="C"/>
+            <fraction n="0.017798" ref="N"/>
+            <fraction n="0.186381" ref="O"/>
+            <fraction n="0.130287" ref="Mg"/>
+            <fraction n="9.0E-4" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_MUSCLE_SKELETAL_ICRP">
+            <D value="1.05" unit="g/cm3"/>
+            <fraction n="0.102" ref="H"/>
+            <fraction n="0.143" ref="C"/>
+            <fraction n="0.034" ref="N"/>
+            <fraction n="0.71" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.002" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.001" ref="Cl"/>
+            <fraction n="0.004" ref="K"/>
+        </material>
+        <material state="solid" name="G4_MUSCLE_STRIATED_ICRU">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.102102" ref="H"/>
+            <fraction n="0.123123" ref="C"/>
+            <fraction n="0.035035" ref="N"/>
+            <fraction n="0.72973" ref="O"/>
+            <fraction n="0.001001" ref="Na"/>
+            <fraction n="0.002002" ref="P"/>
+            <fraction n="0.004004" ref="S"/>
+            <fraction n="0.003003" ref="K"/>
+        </material>
+        <material state="solid" name="G4_MUSCLE_WITH_SUCROSE">
+            <D value="1.11" unit="g/cm3"/>
+            <fraction n="0.098234" ref="H"/>
+            <fraction n="0.156214" ref="C"/>
+            <fraction n="0.035451" ref="N"/>
+            <fraction n="0.710101" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MUSCLE_WITHOUT_SUCROSE">
+            <D value="1.07" unit="g/cm3"/>
+            <fraction n="0.101969" ref="H"/>
+            <fraction n="0.120058" ref="C"/>
+            <fraction n="0.035451" ref="N"/>
+            <fraction n="0.742522" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NAPHTHALENE">
+            <D value="1.145" unit="g/cm3"/>
+            <fraction n="0.937088" ref="C"/>
+            <fraction n="0.062912" ref="H"/>
+        </material>
+        <material state="solid" name="G4_NITROBENZENE">
+            <D value="1.19867" unit="g/cm3"/>
+            <fraction n="0.585368" ref="C"/>
+            <fraction n="0.040937" ref="H"/>
+            <fraction n="0.113775" ref="N"/>
+            <fraction n="0.259921" ref="O"/>
+        </material>
+        <material state="gas" name="G4_NITROUS_OXIDE">
+            <D value="0.00183094" unit="g/cm3"/>
+            <fraction n="0.636484" ref="N"/>
+            <fraction n="0.363516" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NYLON-8062">
+            <D value="1.08" unit="g/cm3"/>
+            <fraction n="0.103509" ref="H"/>
+            <fraction n="0.648416" ref="C"/>
+            <fraction n="0.099536" ref="N"/>
+            <fraction n="0.148539" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NYLON-6-6">
+            <D value="1.14" unit="g/cm3"/>
+            <fraction n="0.636848" ref="C"/>
+            <fraction n="0.097981" ref="H"/>
+            <fraction n="0.123781" ref="N"/>
+            <fraction n="0.14139" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NYLON-6-10">
+            <D value="1.14" unit="g/cm3"/>
+            <fraction n="0.107062" ref="H"/>
+            <fraction n="0.680449" ref="C"/>
+            <fraction n="0.099189" ref="N"/>
+            <fraction n="0.1133" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NYLON-11_RILSAN">
+            <D value="1.425" unit="g/cm3"/>
+            <fraction n="0.115476" ref="H"/>
+            <fraction n="0.720818" ref="C"/>
+            <fraction n="0.076417" ref="N"/>
+            <fraction n="0.087289" ref="O"/>
+        </material>
+        <material state="solid" name="G4_OCTANE">
+            <D value="0.7026" unit="g/cm3"/>
+            <fraction n="0.84117" ref="C"/>
+            <fraction n="0.15883" ref="H"/>
+        </material>
+        <material state="solid" name="G4_PARAFFIN">
+            <D value="0.93" unit="g/cm3"/>
+            <fraction n="0.851387" ref="C"/>
+            <fraction n="0.148613" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-PENTANE">
+            <D value="0.6262" unit="g/cm3"/>
+            <fraction n="0.832357" ref="C"/>
+            <fraction n="0.167643" ref="H"/>
+        </material>
+        <material state="solid" name="G4_PHOTO_EMULSION">
+            <D value="3.815" unit="g/cm3"/>
+            <fraction n="0.0141" ref="H"/>
+            <fraction n="0.072261" ref="C"/>
+            <fraction n="0.01932" ref="N"/>
+            <fraction n="0.066101" ref="O"/>
+            <fraction n="0.00189" ref="S"/>
+            <fraction n="0.349103" ref="Br"/>
+            <fraction n="0.474105" ref="Ag"/>
+            <fraction n="0.00312" ref="I"/>
+        </material>
+        <material state="solid" name="G4_PLASTIC_SC_VINYLTOLUENE">
+            <D value="1.032" unit="g/cm3"/>
+            <fraction n="0.914709" ref="C"/>
+            <fraction n="0.085291" ref="H"/>
+        </material>
+        <material state="solid" name="G4_PLUTONIUM_DIOXIDE">
+            <D value="11.46" unit="g/cm3"/>
+            <fraction n="0.884089" ref="Pu"/>
+            <fraction n="0.115911" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYACRYLONITRILE">
+            <D value="1.17" unit="g/cm3"/>
+            <fraction n="0.679048" ref="C"/>
+            <fraction n="0.056986" ref="H"/>
+            <fraction n="0.263966" ref="N"/>
+        </material>
+        <material state="solid" name="G4_POLYCARBONATE">
+            <D value="1.2" unit="g/cm3"/>
+            <fraction n="0.755745" ref="C"/>
+            <fraction n="0.055494" ref="H"/>
+            <fraction n="0.18876" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYCHLOROSTYRENE">
+            <D value="1.3" unit="g/cm3"/>
+            <fraction n="0.69329" ref="C"/>
+            <fraction n="0.050908" ref="H"/>
+            <fraction n="0.255802" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_POLYETHYLENE">
+            <D value="0.94" unit="g/cm3"/>
+            <fraction n="0.856282" ref="C"/>
+            <fraction n="0.143718" ref="H"/>
+        </material>
+        <material state="solid" name="G4_MYLAR">
+            <D value="1.4" unit="g/cm3"/>
+            <fraction n="0.625011" ref="C"/>
+            <fraction n="0.041961" ref="H"/>
+            <fraction n="0.333028" ref="O"/>
+        </material>
+        <material state="solid" name="G4_PLEXIGLASS">
+            <D value="1.19" unit="g/cm3"/>
+            <fraction n="0.599841" ref="C"/>
+            <fraction n="0.080542" ref="H"/>
+            <fraction n="0.319617" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYOXYMETHYLENE">
+            <D value="1.425" unit="g/cm3"/>
+            <fraction n="0.400011" ref="C"/>
+            <fraction n="0.067138" ref="H"/>
+            <fraction n="0.532851" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYPROPYLENE">
+            <D value="0.9" unit="g/cm3"/>
+            <fraction n="0.856282" ref="C"/>
+            <fraction n="0.143718" ref="H"/>
+        </material>
+        <material state="solid" name="G4_POLYSTYRENE">
+            <D value="1.06" unit="g/cm3"/>
+            <fraction n="0.922577" ref="C"/>
+            <fraction n="0.077423" ref="H"/>
+        </material>
+        <material state="solid" name="G4_TEFLON">
+            <D value="2.2" unit="g/cm3"/>
+            <fraction n="0.240179" ref="C"/>
+            <fraction n="0.759821" ref="F"/>
+        </material>
+        <material state="solid" name="G4_POLYTRIFLUOROCHLOROETHYLENE">
+            <D value="2.1" unit="g/cm3"/>
+            <fraction n="0.206247" ref="C"/>
+            <fraction n="0.489358" ref="F"/>
+            <fraction n="0.304394" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_ACETATE">
+            <D value="1.19" unit="g/cm3"/>
+            <fraction n="0.558059" ref="C"/>
+            <fraction n="0.070248" ref="H"/>
+            <fraction n="0.371693" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_ALCOHOL">
+            <D value="1.3" unit="g/cm3"/>
+            <fraction n="0.54529" ref="C"/>
+            <fraction n="0.091522" ref="H"/>
+            <fraction n="0.363188" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_BUTYRAL">
+            <D value="1.12" unit="g/cm3"/>
+            <fraction n="0.675729" ref="C"/>
+            <fraction n="0.099238" ref="H"/>
+            <fraction n="0.225033" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_CHLORIDE">
+            <D value="1.3" unit="g/cm3"/>
+            <fraction n="0.384357" ref="C"/>
+            <fraction n="0.048383" ref="H"/>
+            <fraction n="0.567261" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYLIDENE_CHLORIDE">
+            <D value="1.7" unit="g/cm3"/>
+            <fraction n="0.247791" ref="C"/>
+            <fraction n="0.020795" ref="H"/>
+            <fraction n="0.731414" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYLIDENE_FLUORIDE">
+            <D value="1.76" unit="g/cm3"/>
+            <fraction n="0.375135" ref="C"/>
+            <fraction n="0.031481" ref="H"/>
+            <fraction n="0.593383" ref="F"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_PYRROLIDONE">
+            <D value="1.25" unit="g/cm3"/>
+            <fraction n="0.648399" ref="C"/>
+            <fraction n="0.08162" ref="H"/>
+            <fraction n="0.126026" ref="N"/>
+            <fraction n="0.143954" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POTASSIUM_IODIDE">
+            <D value="3.13" unit="g/cm3"/>
+            <fraction n="0.235529" ref="K"/>
+            <fraction n="0.764471" ref="I"/>
+        </material>
+        <material state="solid" name="G4_POTASSIUM_OXIDE">
+            <D value="2.32" unit="g/cm3"/>
+            <fraction n="0.830148" ref="K"/>
+            <fraction n="0.169852" ref="O"/>
+        </material>
+        <material state="gas" name="G4_PROPANE">
+            <D value="0.00187939" unit="g/cm3"/>
+            <fraction n="0.817136" ref="C"/>
+            <fraction n="0.182864" ref="H"/>
+        </material>
+        <material state="solid" name="G4_lPROPANE">
+            <D value="0.43" unit="g/cm3"/>
+            <fraction n="0.817136" ref="C"/>
+            <fraction n="0.182864" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-PROPYL_ALCOHOL">
+            <D value="0.8035" unit="g/cm3"/>
+            <fraction n="0.599586" ref="C"/>
+            <fraction n="0.134179" ref="H"/>
+            <fraction n="0.266234" ref="O"/>
+        </material>
+        <material state="solid" name="G4_PYRIDINE">
+            <D value="0.9819" unit="g/cm3"/>
+            <fraction n="0.759211" ref="C"/>
+            <fraction n="0.063713" ref="H"/>
+            <fraction n="0.177076" ref="N"/>
+        </material>
+        <material state="solid" name="G4_RUBBER_BUTYL">
+            <D value="0.92" unit="g/cm3"/>
+            <fraction n="0.143711" ref="H"/>
+            <fraction n="0.856289" ref="C"/>
+        </material>
+        <material state="solid" name="G4_RUBBER_NATURAL">
+            <D value="0.92" unit="g/cm3"/>
+            <fraction n="0.118371" ref="H"/>
+            <fraction n="0.881629" ref="C"/>
+        </material>
+        <material state="solid" name="G4_RUBBER_NEOPRENE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.05692" ref="H"/>
+            <fraction n="0.542646" ref="C"/>
+            <fraction n="0.400434" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_SILICON_DIOXIDE">
+            <D value="2.32" unit="g/cm3"/>
+            <fraction n="0.467434" ref="Si"/>
+            <fraction n="0.532566" ref="O"/>
+        </material>
+        <material state="solid" name="G4_SILVER_BROMIDE">
+            <D value="6.473" unit="g/cm3"/>
+            <fraction n="0.574465" ref="Ag"/>
+            <fraction n="0.425535" ref="Br"/>
+        </material>
+        <material state="solid" name="G4_SILVER_CHLORIDE">
+            <D value="5.56" unit="g/cm3"/>
+            <fraction n="0.752635" ref="Ag"/>
+            <fraction n="0.247365" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_SILVER_HALIDES">
+            <D value="6.47" unit="g/cm3"/>
+            <fraction n="0.422895" ref="Br"/>
+            <fraction n="0.573748" ref="Ag"/>
+            <fraction n="0.003357" ref="I"/>
+        </material>
+        <material state="solid" name="G4_SILVER_IODIDE">
+            <D value="6.01" unit="g/cm3"/>
+            <fraction n="0.459459" ref="Ag"/>
+            <fraction n="0.540541" ref="I"/>
+        </material>
+        <material state="solid" name="G4_SKIN_ICRP">
+            <D value="1.09" unit="g/cm3"/>
+            <fraction n="0.1" ref="H"/>
+            <fraction n="0.204" ref="C"/>
+            <fraction n="0.042" ref="N"/>
+            <fraction n="0.645" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.001" ref="K"/>
+        </material>
+        <material state="solid" name="G4_SODIUM_CARBONATE">
+            <D value="2.532" unit="g/cm3"/>
+            <fraction n="0.433817" ref="Na"/>
+            <fraction n="0.113321" ref="C"/>
+            <fraction n="0.452862" ref="O"/>
+        </material>
+        <material state="solid" name="G4_SODIUM_IODIDE">
+            <D value="3.667" unit="g/cm3"/>
+            <fraction n="0.153374" ref="Na"/>
+            <fraction n="0.846626" ref="I"/>
+        </material>
+        <material state="solid" name="G4_SODIUM_MONOXIDE">
+            <D value="2.27" unit="g/cm3"/>
+            <fraction n="0.741858" ref="Na"/>
+            <fraction n="0.258142" ref="O"/>
+        </material>
+        <material state="solid" name="G4_SODIUM_NITRATE">
+            <D value="2.261" unit="g/cm3"/>
+            <fraction n="0.270485" ref="Na"/>
+            <fraction n="0.164796" ref="N"/>
+            <fraction n="0.564719" ref="O"/>
+        </material>
+        <material state="solid" name="G4_STILBENE">
+            <D value="0.9707" unit="g/cm3"/>
+            <fraction n="0.932896" ref="C"/>
+            <fraction n="0.067104" ref="H"/>
+        </material>
+        <material state="solid" name="G4_SUCROSE">
+            <D value="1.5805" unit="g/cm3"/>
+            <fraction n="0.421064" ref="C"/>
+            <fraction n="0.064782" ref="H"/>
+            <fraction n="0.514154" ref="O"/>
+        </material>
+        <material state="solid" name="G4_TERPHENYL">
+            <D value="1.24" unit="g/cm3"/>
+            <fraction n="0.938728" ref="C"/>
+            <fraction n="0.061272" ref="H"/>
+        </material>
+        <material state="solid" name="G4_TESTIS_ICRP">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.106" ref="H"/>
+            <fraction n="0.099" ref="C"/>
+            <fraction n="0.02" ref="N"/>
+            <fraction n="0.766" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.002" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+        </material>
+        <material state="solid" name="G4_TETRACHLOROETHYLENE">
+            <D value="1.625" unit="g/cm3"/>
+            <fraction n="0.144854" ref="C"/>
+            <fraction n="0.855146" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_THALLIUM_CHLORIDE">
+            <D value="7.004" unit="g/cm3"/>
+            <fraction n="0.85218" ref="Tl"/>
+            <fraction n="0.14782" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_TISSUE_SOFT_ICRP">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.105" ref="H"/>
+            <fraction n="0.256" ref="C"/>
+            <fraction n="0.027" ref="N"/>
+            <fraction n="0.602" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.002" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.002" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+        </material>
+        <material state="solid" name="G4_TISSUE_SOFT_ICRU-4">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.101" ref="H"/>
+            <fraction n="0.111" ref="C"/>
+            <fraction n="0.026" ref="N"/>
+            <fraction n="0.762" ref="O"/>
+        </material>
+        <material state="gas" name="G4_TISSUE-METHANE">
+            <D value="0.00106409" unit="g/cm3"/>
+            <fraction n="0.101869" ref="H"/>
+            <fraction n="0.456179" ref="C"/>
+            <fraction n="0.035172" ref="N"/>
+            <fraction n="0.40678" ref="O"/>
+        </material>
+        <material state="gas" name="G4_TISSUE-PROPANE">
+            <D value="0.00182628" unit="g/cm3"/>
+            <fraction n="0.102672" ref="H"/>
+            <fraction n="0.56894" ref="C"/>
+            <fraction n="0.035022" ref="N"/>
+            <fraction n="0.293366" ref="O"/>
+        </material>
+        <material state="solid" name="G4_TITANIUM_DIOXIDE">
+            <D value="4.26" unit="g/cm3"/>
+            <fraction n="0.599342" ref="Ti"/>
+            <fraction n="0.400658" ref="O"/>
+        </material>
+        <material state="solid" name="G4_TOLUENE">
+            <D value="0.8669" unit="g/cm3"/>
+            <fraction n="0.912485" ref="C"/>
+            <fraction n="0.087515" ref="H"/>
+        </material>
+        <material state="solid" name="G4_TRICHLOROETHYLENE">
+            <D value="1.46" unit="g/cm3"/>
+            <fraction n="0.18283" ref="C"/>
+            <fraction n="0.007672" ref="H"/>
+            <fraction n="0.809499" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_TRIETHYL_PHOSPHATE">
+            <D value="1.07" unit="g/cm3"/>
+            <fraction n="0.395622" ref="C"/>
+            <fraction n="0.083001" ref="H"/>
+            <fraction n="0.351336" ref="O"/>
+            <fraction n="0.170041" ref="P"/>
+        </material>
+        <material state="solid" name="G4_TUNGSTEN_HEXAFLUORIDE">
+            <D value="2.4" unit="g/cm3"/>
+            <fraction n="0.617266" ref="W"/>
+            <fraction n="0.382734" ref="F"/>
+        </material>
+        <material state="solid" name="G4_URANIUM_DICARBIDE">
+            <D value="11.28" unit="g/cm3"/>
+            <fraction n="0.908333" ref="U"/>
+            <fraction n="0.091667" ref="C"/>
+        </material>
+        <material state="solid" name="G4_URANIUM_MONOCARBIDE">
+            <D value="13.63" unit="g/cm3"/>
+            <fraction n="0.951965" ref="U"/>
+            <fraction n="0.048035" ref="C"/>
+        </material>
+        <material state="solid" name="G4_URANIUM_OXIDE">
+            <D value="10.96" unit="g/cm3"/>
+            <fraction n="0.881498" ref="U"/>
+            <fraction n="0.118502" ref="O"/>
+        </material>
+        <material state="solid" name="G4_UREA">
+            <D value="1.323" unit="g/cm3"/>
+            <fraction n="0.199994" ref="C"/>
+            <fraction n="0.067134" ref="H"/>
+            <fraction n="0.466461" ref="N"/>
+            <fraction n="0.26641" ref="O"/>
+        </material>
+        <material state="solid" name="G4_VALINE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.512637" ref="C"/>
+            <fraction n="0.094645" ref="H"/>
+            <fraction n="0.119566" ref="N"/>
+            <fraction n="0.273152" ref="O"/>
+        </material>
+        <material state="solid" name="G4_VITON">
+            <D value="1.8" unit="g/cm3"/>
+            <fraction n="0.009417" ref="H"/>
+            <fraction n="0.280555" ref="C"/>
+            <fraction n="0.710028" ref="F"/>
+        </material>
+        <material state="gas" name="G4_WATER_VAPOR">
+            <D value="7.56182E-4" unit="g/cm3"/>
+            <fraction n="0.111898" ref="H"/>
+            <fraction n="0.888102" ref="O"/>
+        </material>
+        <material state="solid" name="G4_XYLENE">
+            <D value="0.87" unit="g/cm3"/>
+            <fraction n="0.905059" ref="C"/>
+            <fraction n="0.094941" ref="H"/>
+        </material>
+        <material state="solid" name="G4_GRAPHITE">
+            <D value="2.21" unit="g/cm3"/>
+            <fraction n="1.0" ref="C"/>
+        </material>
+        <material state="liquid" name="G4_lH2">
+            <D value="0.0708" unit="g/cm3"/>
+            <fraction n="1.0" ref="H"/>
+        </material>
+        <material state="liquid" name="G4_lN2">
+            <D value="0.807" unit="g/cm3"/>
+            <fraction n="1.0" ref="N"/>
+        </material>
+        <material state="liquid" name="G4_lO2">
+            <D value="1.141" unit="g/cm3"/>
+            <fraction n="1.0" ref="O"/>
+        </material>
+        <material state="liquid" name="G4_lAr">
+            <D value="1.396" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ar"/>
+        </material>
+        <material state="liquid" name="G4_lBr">
+            <D value="3.1028" unit="g/cm3"/>
+            <fraction n="1.0" ref="Br"/>
+        </material>
+        <material state="liquid" name="G4_lKr">
+            <D value="2.418" unit="g/cm3"/>
+            <fraction n="1.0" ref="Kr"/>
+        </material>
+        <material state="liquid" name="G4_lXe">
+            <D value="2.953" unit="g/cm3"/>
+            <fraction n="1.0" ref="Xe"/>
+        </material>
+        <material state="solid" name="G4_PbWO4">
+            <D value="8.28" unit="g/cm3"/>
+            <fraction n="0.140637" ref="O"/>
+            <fraction n="0.455366" ref="Pb"/>
+            <fraction n="0.403998" ref="W"/>
+        </material>
+        <material state="gas" name="G4_Galactic">
+            <D value="1.0E-25" unit="g/cm3"/>
+            <fraction n="1.0" ref="H"/>
+        </material>
+        <material state="solid" name="G4_GRAPHITE_POROUS">
+            <D value="1.7" unit="g/cm3"/>
+            <fraction n="1.0" ref="C"/>
+        </material>
+        <material state="solid" name="G4_LUCITE">
+            <D value="1.19" unit="g/cm3"/>
+            <fraction n="0.080538" ref="H"/>
+            <fraction n="0.599848" ref="C"/>
+            <fraction n="0.319614" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BRASS">
+            <D value="8.52" unit="g/cm3"/>
+            <fraction n="0.57513" ref="Cu"/>
+            <fraction n="0.334122" ref="Zn"/>
+            <fraction n="0.090748" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_BRONZE">
+            <D value="8.82" unit="g/cm3"/>
+            <fraction n="0.849368" ref="Cu"/>
+            <fraction n="0.088391" ref="Zn"/>
+            <fraction n="0.062241" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_STAINLESS-STEEL">
+            <D value="8.0" unit="g/cm3"/>
+            <fraction n="0.746213" ref="Fe"/>
+            <fraction n="0.169001" ref="Cr"/>
+            <fraction n="0.084786" ref="Ni"/>
+        </material>
+        <material state="solid" name="G4_CR39">
+            <D value="1.32" unit="g/cm3"/>
+            <fraction n="0.066151" ref="H"/>
+            <fraction n="0.525505" ref="C"/>
+            <fraction n="0.408345" ref="O"/>
+        </material>
+        <material state="solid" name="G4_OCTADECANOL">
+            <D value="0.812" unit="g/cm3"/>
+            <fraction n="0.141599" ref="H"/>
+            <fraction n="0.799252" ref="C"/>
+            <fraction n="0.059149" ref="O"/>
+        </material>
+        <material state="solid" name="G4_KEVLAR">
+            <D value="1.44" unit="g/cm3"/>
+            <fraction n="0.705796" ref="C"/>
+            <fraction n="0.042307" ref="H"/>
+            <fraction n="0.134312" ref="O"/>
+            <fraction n="0.117584" ref="N"/>
+        </material>
+        <material state="solid" name="G4_DACRON">
+            <D value="1.4" unit="g/cm3"/>
+            <fraction n="0.625011" ref="C"/>
+            <fraction n="0.041961" ref="H"/>
+            <fraction n="0.333028" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NEOPRENE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.542642" ref="C"/>
+            <fraction n="0.056923" ref="H"/>
+            <fraction n="0.400435" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_CYTOSINE">
+            <D value="1.55" unit="g/cm3"/>
+            <fraction n="0.045361" ref="H"/>
+            <fraction n="0.432421" ref="C"/>
+            <fraction n="0.378213" ref="N"/>
+            <fraction n="0.144006" ref="O"/>
+        </material>
+        <material state="solid" name="G4_THYMINE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.047954" ref="H"/>
+            <fraction n="0.476187" ref="C"/>
+            <fraction n="0.222129" ref="N"/>
+            <fraction n="0.25373" ref="O"/>
+        </material>
+        <material state="solid" name="G4_URACIL">
+            <D value="1.32" unit="g/cm3"/>
+            <fraction n="0.03597" ref="H"/>
+            <fraction n="0.428622" ref="C"/>
+            <fraction n="0.249927" ref="N"/>
+            <fraction n="0.285482" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DEOXYRIBOSE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.085324" ref="H"/>
+            <fraction n="0.508364" ref="C"/>
+            <fraction n="0.406312" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_DEOXYRIBOSE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.084896" ref="H"/>
+            <fraction n="0.722592" ref="C"/>
+            <fraction n="0.192512" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_PHOSPHATE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.326138" ref="P"/>
+            <fraction n="0.673862" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_ADENINE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.030061" ref="H"/>
+            <fraction n="0.447763" ref="C"/>
+            <fraction n="0.522176" ref="N"/>
+        </material>
+        <material state="solid" name="G4_DNA_GUANINE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.026857" ref="H"/>
+            <fraction n="0.400041" ref="C"/>
+            <fraction n="0.466523" ref="N"/>
+            <fraction n="0.106578" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_CYTOSINE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.036621" ref="H"/>
+            <fraction n="0.43638" ref="C"/>
+            <fraction n="0.381675" ref="N"/>
+            <fraction n="0.145324" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_THYMINE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.040284" ref="H"/>
+            <fraction n="0.480024" ref="C"/>
+            <fraction n="0.223919" ref="N"/>
+            <fraction n="0.255774" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_URACIL">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.027222" ref="H"/>
+            <fraction n="0.432511" ref="C"/>
+            <fraction n="0.252195" ref="N"/>
+            <fraction n="0.288072" ref="O"/>
+        </material>
+        <material state="gas" name="Vacuum">
+            <D value="1.0E-20" unit="g/cm3"/>
+            <fraction n="0.7" ref="G4_N"/>
+            <fraction n="0.3" ref="G4_O"/>
+        </material>
+        <material state="solid" name="BC408">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.085" ref="G4_H"/>
+            <fraction n="0.915" ref="G4_C"/>
+        </material>
+        <material state="solid" name="PVT">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.085" ref="G4_H"/>
+            <fraction n="0.915" ref="G4_C"/>
+        </material>
+        <element name="6Li">
+            <fraction n="1.0" ref="Li6"/>
+        </element>
+        <material state="solid" name="6LiI">
+            <D value="3.494" unit="g/cm3"/>
+            <fraction n="0.045113" ref="6Li"/>
+            <fraction n="0.954887" ref="I"/>
+        </material>
+        <material state="solid" name="LUNG20_AIR80">
+            <D value="0.209" unit="g/cm3"/>
+            <fraction n="0.2" ref="G4_LUNG_ICRP"/>
+            <fraction n="0.8" ref="G4_AIR"/>
+        </material>
+        <material state="solid" name="BoratedHDPE5pct">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.05" ref="G4_B"/>
+            <fraction n="0.95" ref="G4_POLYETHYLENE"/>
+        </material>
+        <material state="solid" name="BoratedHDPE1pct">
+            <D value="0.96" unit="g/cm3"/>
+            <fraction n="0.01" ref="G4_B"/>
+            <fraction n="0.99" ref="G4_POLYETHYLENE"/>
+        </material>
+        <material state="solid" name="EJ254-5pct">
+            <D value="1.026" unit="g/cm3"/>
+            <fraction n="0.084647652" ref="G4_H"/>
+            <fraction n="0.865300985" ref="G4_C"/>
+            <fraction n="0.050051363" ref="G4_B"/>
+        </material>
+        <material state="solid" name="EJ254-2.5pct">
+            <D value="1.023" unit="g/cm3"/>
+            <fraction n="0.084809873" ref="G4_H"/>
+            <fraction n="0.890156445" ref="G4_C"/>
+            <fraction n="0.025033682" ref="G4_B"/>
+        </material>
+        <material state="solid" name="EJ254-1pct">
+            <D value="1.021" unit="g/cm3"/>
+            <fraction n="0.084766095" ref="G4_H"/>
+            <fraction n="0.905135339" ref="G4_C"/>
+            <fraction n="0.010098567" ref="G4_B"/>
+        </material>
+        <material state="solid" name="mirrobor_B4C">
+            <D value="1.55" unit="g/cm3"/>
+            <fraction n="0.2080661841" ref="G4_C"/>
+            <fraction n="0.7919338159" ref="G4_B"/>
+        </material>
+        <material state="solid" name="mirrobor_additives">
+            <D value="1.55" unit="g/cm3"/>
+            <fraction n="0.7" ref="G4_C"/>
+            <fraction n="0.25" ref="G4_O"/>
+            <fraction n="0.05" ref="G4_H"/>
+        </material>
+        <material state="solid" name="mirrobor">
+            <D value="1.55" unit="g/cm3"/>
+            <fraction n="0.8" ref="mirrobor_B4C"/>
+            <fraction n="0.2" ref="mirrobor_additives"/>
+        </material>
+        <material state="liquid" name="LiquidScintillatorBase">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.085" ref="G4_H"/>
+            <fraction n="0.915" ref="G4_C"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator1pctPb">
+            <D value="1.1332" unit="g/cm3"/>
+            <fraction n="0.01" ref="G4_Pb"/>
+            <fraction n="0.99" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator2pctPb">
+            <D value="1.2364" unit="g/cm3"/>
+            <fraction n="0.02" ref="G4_Pb"/>
+            <fraction n="0.98" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator3pctPb">
+            <D value="1.3396" unit="g/cm3"/>
+            <fraction n="0.03" ref="G4_Pb"/>
+            <fraction n="0.97" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator4pctPb">
+            <D value="1.4428" unit="g/cm3"/>
+            <fraction n="0.04" ref="G4_Pb"/>
+            <fraction n="0.96" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator5pctPb">
+            <D value="1.546" unit="g/cm3"/>
+            <fraction n="0.05" ref="G4_Pb"/>
+            <fraction n="0.95" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator6pctPb">
+            <D value="1.6492" unit="g/cm3"/>
+            <fraction n="0.06" ref="G4_Pb"/>
+            <fraction n="0.94" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator7pctPb">
+            <D value="1.7524" unit="g/cm3"/>
+            <fraction n="0.07" ref="G4_Pb"/>
+            <fraction n="0.93" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator8pctPb">
+            <D value="1.8556" unit="g/cm3"/>
+            <fraction n="0.08" ref="G4_Pb"/>
+            <fraction n="0.92" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator9pctPb">
+            <D value="1.9588" unit="g/cm3"/>
+            <fraction n="0.09" ref="G4_Pb"/>
+            <fraction n="0.91" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator10pctPb">
+            <D value="2.062" unit="g/cm3"/>
+            <fraction n="0.1" ref="G4_Pb"/>
+            <fraction n="0.9" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator11pctPb">
+            <D value="2.1652" unit="g/cm3"/>
+            <fraction n="0.11" ref="G4_Pb"/>
+            <fraction n="0.89" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator12pctPb">
+            <D value="2.2684" unit="g/cm3"/>
+            <fraction n="0.12" ref="G4_Pb"/>
+            <fraction n="0.88" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator13pctPb">
+            <D value="2.3716" unit="g/cm3"/>
+            <fraction n="0.13" ref="G4_Pb"/>
+            <fraction n="0.87" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator14pctPb">
+            <D value="2.4748" unit="g/cm3"/>
+            <fraction n="0.14" ref="G4_Pb"/>
+            <fraction n="0.86" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator15pctPb">
+            <D value="2.578" unit="g/cm3"/>
+            <fraction n="0.15" ref="G4_Pb"/>
+            <fraction n="0.85" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator16pctPb">
+            <D value="2.6812" unit="g/cm3"/>
+            <fraction n="0.16" ref="G4_Pb"/>
+            <fraction n="0.84" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator17pctPb">
+            <D value="2.7844" unit="g/cm3"/>
+            <fraction n="0.17" ref="G4_Pb"/>
+            <fraction n="0.83" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator18pctPb">
+            <D value="2.8876" unit="g/cm3"/>
+            <fraction n="0.18" ref="G4_Pb"/>
+            <fraction n="0.82" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator19pctPb">
+            <D value="2.9908" unit="g/cm3"/>
+            <fraction n="0.19" ref="G4_Pb"/>
+            <fraction n="0.81" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator20pctPb">
+            <D value="3.094" unit="g/cm3"/>
+            <fraction n="0.2" ref="G4_Pb"/>
+            <fraction n="0.8" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator21pctPb">
+            <D value="3.1972" unit="g/cm3"/>
+            <fraction n="0.21" ref="G4_Pb"/>
+            <fraction n="0.79" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator22pctPb">
+            <D value="3.3004" unit="g/cm3"/>
+            <fraction n="0.22" ref="G4_Pb"/>
+            <fraction n="0.78" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator23pctPb">
+            <D value="3.4036" unit="g/cm3"/>
+            <fraction n="0.23" ref="G4_Pb"/>
+            <fraction n="0.77" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator24pctPb">
+            <D value="3.5068" unit="g/cm3"/>
+            <fraction n="0.24" ref="G4_Pb"/>
+            <fraction n="0.76" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator25pctPb">
+            <D value="3.61" unit="g/cm3"/>
+            <fraction n="0.25" ref="G4_Pb"/>
+            <fraction n="0.75" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator26pctPb">
+            <D value="3.7132" unit="g/cm3"/>
+            <fraction n="0.26" ref="G4_Pb"/>
+            <fraction n="0.74" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator27pctPb">
+            <D value="3.8164" unit="g/cm3"/>
+            <fraction n="0.27" ref="G4_Pb"/>
+            <fraction n="0.73" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator28pctPb">
+            <D value="3.9196" unit="g/cm3"/>
+            <fraction n="0.28" ref="G4_Pb"/>
+            <fraction n="0.72" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator29pctPb">
+            <D value="4.0228" unit="g/cm3"/>
+            <fraction n="0.29" ref="G4_Pb"/>
+            <fraction n="0.71" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator30pctPb">
+            <D value="4.126" unit="g/cm3"/>
+            <fraction n="0.3" ref="G4_Pb"/>
+            <fraction n="0.7" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator31pctPb">
+            <D value="4.2292" unit="g/cm3"/>
+            <fraction n="0.31" ref="G4_Pb"/>
+            <fraction n="0.69" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator32pctPb">
+            <D value="4.3324" unit="g/cm3"/>
+            <fraction n="0.32" ref="G4_Pb"/>
+            <fraction n="0.68" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator33pctPb">
+            <D value="4.4356" unit="g/cm3"/>
+            <fraction n="0.33" ref="G4_Pb"/>
+            <fraction n="0.67" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator34pctPb">
+            <D value="4.5388" unit="g/cm3"/>
+            <fraction n="0.34" ref="G4_Pb"/>
+            <fraction n="0.66" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator35pctPb">
+            <D value="4.642" unit="g/cm3"/>
+            <fraction n="0.35" ref="G4_Pb"/>
+            <fraction n="0.65" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator36pctPb">
+            <D value="4.7452" unit="g/cm3"/>
+            <fraction n="0.36" ref="G4_Pb"/>
+            <fraction n="0.64" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator37pctPb">
+            <D value="4.8484" unit="g/cm3"/>
+            <fraction n="0.37" ref="G4_Pb"/>
+            <fraction n="0.63" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator38pctPb">
+            <D value="4.9516" unit="g/cm3"/>
+            <fraction n="0.38" ref="G4_Pb"/>
+            <fraction n="0.62" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator39pctPb">
+            <D value="5.0548" unit="g/cm3"/>
+            <fraction n="0.39" ref="G4_Pb"/>
+            <fraction n="0.61" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator40pctPb">
+            <D value="5.158" unit="g/cm3"/>
+            <fraction n="0.4" ref="G4_Pb"/>
+            <fraction n="0.6" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator41pctPb">
+            <D value="5.2612" unit="g/cm3"/>
+            <fraction n="0.41" ref="G4_Pb"/>
+            <fraction n="0.59" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator42pctPb">
+            <D value="5.3644" unit="g/cm3"/>
+            <fraction n="0.42" ref="G4_Pb"/>
+            <fraction n="0.58" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator43pctPb">
+            <D value="5.4676" unit="g/cm3"/>
+            <fraction n="0.43" ref="G4_Pb"/>
+            <fraction n="0.57" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator44pctPb">
+            <D value="5.5708" unit="g/cm3"/>
+            <fraction n="0.44" ref="G4_Pb"/>
+            <fraction n="0.56" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator45pctPb">
+            <D value="5.674" unit="g/cm3"/>
+            <fraction n="0.45" ref="G4_Pb"/>
+            <fraction n="0.55" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator46pctPb">
+            <D value="5.7772" unit="g/cm3"/>
+            <fraction n="0.46" ref="G4_Pb"/>
+            <fraction n="0.54" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator47pctPb">
+            <D value="5.8804" unit="g/cm3"/>
+            <fraction n="0.47" ref="G4_Pb"/>
+            <fraction n="0.53" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator48pctPb">
+            <D value="5.9836" unit="g/cm3"/>
+            <fraction n="0.48" ref="G4_Pb"/>
+            <fraction n="0.52" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator49pctPb">
+            <D value="6.0868" unit="g/cm3"/>
+            <fraction n="0.49" ref="G4_Pb"/>
+            <fraction n="0.51" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator50pctPb">
+            <D value="6.19" unit="g/cm3"/>
+            <fraction n="0.5" ref="G4_Pb"/>
+            <fraction n="0.5" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator51pctPb">
+            <D value="6.2932" unit="g/cm3"/>
+            <fraction n="0.51" ref="G4_Pb"/>
+            <fraction n="0.49" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator52pctPb">
+            <D value="6.3964" unit="g/cm3"/>
+            <fraction n="0.52" ref="G4_Pb"/>
+            <fraction n="0.48" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator53pctPb">
+            <D value="6.4996" unit="g/cm3"/>
+            <fraction n="0.53" ref="G4_Pb"/>
+            <fraction n="0.47" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator54pctPb">
+            <D value="6.6028" unit="g/cm3"/>
+            <fraction n="0.54" ref="G4_Pb"/>
+            <fraction n="0.46" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator55pctPb">
+            <D value="6.706" unit="g/cm3"/>
+            <fraction n="0.55" ref="G4_Pb"/>
+            <fraction n="0.45" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator56pctPb">
+            <D value="6.8092" unit="g/cm3"/>
+            <fraction n="0.56" ref="G4_Pb"/>
+            <fraction n="0.44" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator57pctPb">
+            <D value="6.9124" unit="g/cm3"/>
+            <fraction n="0.57" ref="G4_Pb"/>
+            <fraction n="0.43" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator58pctPb">
+            <D value="7.0156" unit="g/cm3"/>
+            <fraction n="0.58" ref="G4_Pb"/>
+            <fraction n="0.42" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator59pctPb">
+            <D value="7.1188" unit="g/cm3"/>
+            <fraction n="0.59" ref="G4_Pb"/>
+            <fraction n="0.41" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator60pctPb">
+            <D value="7.222" unit="g/cm3"/>
+            <fraction n="0.6" ref="G4_Pb"/>
+            <fraction n="0.4" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator61pctPb">
+            <D value="7.3252" unit="g/cm3"/>
+            <fraction n="0.61" ref="G4_Pb"/>
+            <fraction n="0.39" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator62pctPb">
+            <D value="7.4284" unit="g/cm3"/>
+            <fraction n="0.62" ref="G4_Pb"/>
+            <fraction n="0.38" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator63pctPb">
+            <D value="7.5316" unit="g/cm3"/>
+            <fraction n="0.63" ref="G4_Pb"/>
+            <fraction n="0.37" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator64pctPb">
+            <D value="7.6348" unit="g/cm3"/>
+            <fraction n="0.64" ref="G4_Pb"/>
+            <fraction n="0.36" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator65pctPb">
+            <D value="7.738" unit="g/cm3"/>
+            <fraction n="0.65" ref="G4_Pb"/>
+            <fraction n="0.35" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator66pctPb">
+            <D value="7.8412" unit="g/cm3"/>
+            <fraction n="0.66" ref="G4_Pb"/>
+            <fraction n="0.34" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator67pctPb">
+            <D value="7.9444" unit="g/cm3"/>
+            <fraction n="0.67" ref="G4_Pb"/>
+            <fraction n="0.33" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator68pctPb">
+            <D value="8.0476" unit="g/cm3"/>
+            <fraction n="0.68" ref="G4_Pb"/>
+            <fraction n="0.32" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator69pctPb">
+            <D value="8.1508" unit="g/cm3"/>
+            <fraction n="0.69" ref="G4_Pb"/>
+            <fraction n="0.31" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator70pctPb">
+            <D value="8.254" unit="g/cm3"/>
+            <fraction n="0.7" ref="G4_Pb"/>
+            <fraction n="0.3" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator71pctPb">
+            <D value="8.3572" unit="g/cm3"/>
+            <fraction n="0.71" ref="G4_Pb"/>
+            <fraction n="0.29" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator72pctPb">
+            <D value="8.4604" unit="g/cm3"/>
+            <fraction n="0.72" ref="G4_Pb"/>
+            <fraction n="0.28" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator73pctPb">
+            <D value="8.5636" unit="g/cm3"/>
+            <fraction n="0.73" ref="G4_Pb"/>
+            <fraction n="0.27" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator74pctPb">
+            <D value="8.6668" unit="g/cm3"/>
+            <fraction n="0.74" ref="G4_Pb"/>
+            <fraction n="0.26" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator75pctPb">
+            <D value="8.77" unit="g/cm3"/>
+            <fraction n="0.75" ref="G4_Pb"/>
+            <fraction n="0.25" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator76pctPb">
+            <D value="8.8732" unit="g/cm3"/>
+            <fraction n="0.76" ref="G4_Pb"/>
+            <fraction n="0.24" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator77pctPb">
+            <D value="8.9764" unit="g/cm3"/>
+            <fraction n="0.77" ref="G4_Pb"/>
+            <fraction n="0.23" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator78pctPb">
+            <D value="9.0796" unit="g/cm3"/>
+            <fraction n="0.78" ref="G4_Pb"/>
+            <fraction n="0.22" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator79pctPb">
+            <D value="9.1828" unit="g/cm3"/>
+            <fraction n="0.79" ref="G4_Pb"/>
+            <fraction n="0.21" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator80pctPb">
+            <D value="9.286" unit="g/cm3"/>
+            <fraction n="0.8" ref="G4_Pb"/>
+            <fraction n="0.2" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator81pctPb">
+            <D value="9.3892" unit="g/cm3"/>
+            <fraction n="0.81" ref="G4_Pb"/>
+            <fraction n="0.19" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator82pctPb">
+            <D value="9.4924" unit="g/cm3"/>
+            <fraction n="0.82" ref="G4_Pb"/>
+            <fraction n="0.18" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator83pctPb">
+            <D value="9.5956" unit="g/cm3"/>
+            <fraction n="0.83" ref="G4_Pb"/>
+            <fraction n="0.17" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator84pctPb">
+            <D value="9.6988" unit="g/cm3"/>
+            <fraction n="0.84" ref="G4_Pb"/>
+            <fraction n="0.16" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator85pctPb">
+            <D value="9.802" unit="g/cm3"/>
+            <fraction n="0.85" ref="G4_Pb"/>
+            <fraction n="0.15" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator86pctPb">
+            <D value="9.9052" unit="g/cm3"/>
+            <fraction n="0.86" ref="G4_Pb"/>
+            <fraction n="0.14" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator87pctPb">
+            <D value="10.0084" unit="g/cm3"/>
+            <fraction n="0.87" ref="G4_Pb"/>
+            <fraction n="0.13" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator88pctPb">
+            <D value="10.1116" unit="g/cm3"/>
+            <fraction n="0.88" ref="G4_Pb"/>
+            <fraction n="0.12" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator89pctPb">
+            <D value="10.2148" unit="g/cm3"/>
+            <fraction n="0.89" ref="G4_Pb"/>
+            <fraction n="0.11" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator90pctPb">
+            <D value="10.318" unit="g/cm3"/>
+            <fraction n="0.9" ref="G4_Pb"/>
+            <fraction n="0.1" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator91pctPb">
+            <D value="10.4212" unit="g/cm3"/>
+            <fraction n="0.91" ref="G4_Pb"/>
+            <fraction n="0.09" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator92pctPb">
+            <D value="10.5244" unit="g/cm3"/>
+            <fraction n="0.92" ref="G4_Pb"/>
+            <fraction n="0.08" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator93pctPb">
+            <D value="10.6276" unit="g/cm3"/>
+            <fraction n="0.93" ref="G4_Pb"/>
+            <fraction n="0.07" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator94pctPb">
+            <D value="10.7308" unit="g/cm3"/>
+            <fraction n="0.94" ref="G4_Pb"/>
+            <fraction n="0.06" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator95pctPb">
+            <D value="10.834" unit="g/cm3"/>
+            <fraction n="0.95" ref="G4_Pb"/>
+            <fraction n="0.05" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator96pctPb">
+            <D value="10.9372" unit="g/cm3"/>
+            <fraction n="0.96" ref="G4_Pb"/>
+            <fraction n="0.04" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator97pctPb">
+            <D value="11.0404" unit="g/cm3"/>
+            <fraction n="0.97" ref="G4_Pb"/>
+            <fraction n="0.03" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator98pctPb">
+            <D value="11.1436" unit="g/cm3"/>
+            <fraction n="0.98" ref="G4_Pb"/>
+            <fraction n="0.02" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator99pctPb">
+            <D value="11.2468" unit="g/cm3"/>
+            <fraction n="0.99" ref="G4_Pb"/>
+            <fraction n="0.01" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="gas" name="TMAGas">
+            <D value="6.7" unit="kg/m3"/>
+            <fraction n="0.6095775385572637" ref="C"/>
+            <fraction n="0.1534682886203227" ref="H"/>
+            <fraction n="0.2369541728224135" ref="N"/>
+        </material>
+        <material state="gas" name="IsobutaneGas">
+            <D value="2.38467" unit="kg/m3"/>
+            <fraction n="0.8265819278538703" ref="C"/>
+            <fraction n="0.1734180721461297" ref="H"/>
+        </material>
+        <material state="gas" name="HeliumGas">
+            <D value="0.125" unit="kg/m3"/>
+            <fraction n="1.0" ref="He"/>
+        </material>
+        <material state="gas" name="XenonGas">
+            <D value="5.894" unit="kg/m3"/>
+            <fraction n="1.0" ref="Xe"/>
+        </material>
+        <material state="gas" name="ArgonGas">
+            <D value="1.63897" unit="kg/m3"/>
+            <fraction n="1.0" ref="Ar"/>
+        </material>
+        <material state="gas" name="Xenon50Neon50Gas">
+            <D value="3.0553" unit="kg/m3"/>
+            <fraction n="0.8667868153341387" ref="Xe"/>
+            <fraction n="0.1332131846658613" ref="Ne"/>
+        </material>
+        <material state="gas" name="Argon1%Isobutane1bar">
+            <D value="1.61882" unit="kg/m3"/>
+            <fraction n="0.9855" ref="ArgonGas"/>
+            <fraction n="0.0145" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="Argon2%Isobutane1bar">
+            <D value="1.62615" unit="kg/m3"/>
+            <fraction n="0.9711" ref="ArgonGas"/>
+            <fraction n="0.0289" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="Argon3%Isobutane1bar">
+            <D value="1.63348" unit="kg/m3"/>
+            <fraction n="0.9569" ref="ArgonGas"/>
+            <fraction n="0.0431" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="Argon4%Isobutane1bar">
+            <D value="1.64081" unit="kg/m3"/>
+            <fraction n="0.9428" ref="ArgonGas"/>
+            <fraction n="0.0572" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="Argon5%Isobutane1bar">
+            <D value="1.64814" unit="kg/m3"/>
+            <fraction n="0.9288" ref="ArgonGas"/>
+            <fraction n="0.0712" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="Argon10%Isobutane1bar">
+            <D value="1.6848" unit="kg/m3"/>
+            <fraction n="0.8608" ref="ArgonGas"/>
+            <fraction n="0.1392" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="XenonNeon1%Isobutane1bar">
+            <D value="3.04819" unit="kg/m3"/>
+            <fraction n="0.99230795006" ref="Xenon50Neon50Gas"/>
+            <fraction n="0.00769204994" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="XenonNeon2.3%Isobutane1bar">
+            <D value="3.03895" unit="kg/m3"/>
+            <fraction n="0.98225450491" ref="Xenon50Neon50Gas"/>
+            <fraction n="0.01774549509" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="XenonNeon5%Isobutane1bar">
+            <D value="3.01977" unit="kg/m3"/>
+            <fraction n="0.961177731" ref="Xenon50Neon50Gas"/>
+            <fraction n="0.038822269" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="Argon1%Isobutane1.2bar">
+            <D value="1.942584" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon1%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon2%Isobutane1.2bar">
+            <D value="1.95138" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon2%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon3%Isobutane1.2bar">
+            <D value="1.960176" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon4%Isobutane1.2bar">
+            <D value="1.968972" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon4%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon5%Isobutane1.2bar">
+            <D value="1.977768" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon5%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon10%Isobutane1.2bar">
+            <D value="2.02176" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon10%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon1%Isobutane1.4bar">
+            <D value="2.266348" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon1%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon2%Isobutane1.4bar">
+            <D value="2.27661" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon2%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon3%Isobutane1.4bar">
+            <D value="2.286872" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon4%Isobutane1.4bar">
+            <D value="2.297134" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon4%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon5%Isobutane1.4bar">
+            <D value="2.307396" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon5%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon10%Isobutane1.4bar">
+            <D value="2.35872" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon10%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon1%Isobutane1.5bar">
+            <D value="2.42836" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon1%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon2%Isobutane1.5bar">
+            <D value="2.43936" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon2%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon3%Isobutane1.5bar">
+            <D value="2.45036" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon4%Isobutane1.5bar">
+            <D value="2.46136" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon4%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon5%Isobutane1.5bar">
+            <D value="2.47235" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon5%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon10%Isobutane1.5bar">
+            <D value="2.52735" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon10%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon1%Isobutane1.6bar">
+            <D value="2.590112" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon1%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon2%Isobutane1.6bar">
+            <D value="2.60184" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon2%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon3%Isobutane1.6bar">
+            <D value="2.613568" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon4%Isobutane1.6bar">
+            <D value="2.625296" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon4%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon5%Isobutane1.6bar">
+            <D value="2.637024" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon5%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon10%Isobutane1.6bar">
+            <D value="2.69568" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon10%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon1%Isobutane2.0bar">
+            <D value="3.23781" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon1%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon2%Isobutane2.0bar">
+            <D value="3.25248" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon2%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon3%Isobutane2.0bar">
+            <D value="3.26714" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon4%Isobutane2.0bar">
+            <D value="3.28181" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon4%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon5%Isobutane2.0bar">
+            <D value="3.29647" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon5%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon10%Isobutane2.0bar">
+            <D value="3.3698" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon10%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="XenonNeon2.3%Isobutane1.05bar">
+            <D value="3.1908975" unit="kg/m3"/>
+            <fraction n="1.0" ref="XenonNeon2.3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="XenonNeon2.3%Isobutane1.5bar">
+            <D value="4.5585" unit="kg/m3"/>
+            <fraction n="1.0" ref="XenonNeon2.3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="XenonNeon2.3%Isobutane2.0bar">
+            <D value="6.078" unit="kg/m3"/>
+            <fraction n="1.0" ref="XenonNeon2.3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="XenonNeon5%Isobutane1.5bar">
+            <D value="4.52972" unit="kg/m3"/>
+            <fraction n="1.0" ref="XenonNeon5%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="XenonNeon5%Isobutane2.0bar">
+            <D value="6.03963" unit="kg/m3"/>
+            <fraction n="1.0" ref="XenonNeon5%Isobutane1bar"/>
+        </material>
+        <material state="solid" name="Copper">
+            <D value="8.96" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cu"/>
+        </material>
+        <material state="solid" name="Lead">
+            <D value="11.35" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pb"/>
+        </material>
+        <material state="solid" name="Aluminium">
+            <D value="2.699" unit="g/cm3"/>
+            <fraction n="1.0" ref="Al"/>
+        </material>
+        <material state="solid" name="Cadmium">
+            <D value="8.65" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cd"/>
+        </material>
+        <material state="solid" name="Steel">
+            <D value="8.0" unit="g/cm3"/>
+            <fraction n="0.746213" ref="Fe"/>
+            <fraction n="0.169001" ref="Cr"/>
+            <fraction n="0.084786" ref="Ni"/>
+        </material>
+        <material state="solid" name="StainlessSteel">
+            <D value="8.0" unit="g/cm3"/>
+            <fraction n="0.746213" ref="Fe"/>
+            <fraction n="0.169001" ref="Cr"/>
+            <fraction n="0.084786" ref="Ni"/>
+        </material>
+        <material state="solid" name="Water">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.111898" ref="H"/>
+            <fraction n="0.888102" ref="O"/>
+        </material>
+        <material state="gas" name="Air">
+            <D value="0.00120479" unit="g/cm3"/>
+            <fraction n="1.24E-4" ref="C"/>
+            <fraction n="0.755268" ref="N"/>
+            <fraction n="0.231781" ref="O"/>
+            <fraction n="0.012827" ref="Ar"/>
+        </material>
+    </materials>
+    <solids>
+        <box lunit="mm" aunit="rad" name="chamberBodyBaseSolid" x="134.0" y="134.0" z="30.0"/>
+        <tube lunit="mm" aunit="rad" name="chamberBodyHoleSolid" rmax="51.0" z="30.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="chamberBodySolid">
+            <first ref="chamberBodyBaseSolid"/>
+            <second ref="chamberBodyHoleSolid"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="chamberBackplateSolid" x="134.0" y="134.0" z="15.0"/>
+        <tube lunit="mm" aunit="rad" name="chamberTeflonWallSolid" rmax="51.0" z="30.0" rmin="50.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <box lunit="mm" aunit="rad" name="kaptonReadoutSolid" x="134.0" y="134.0" z="0.5"/>
+        <box lunit="mm" aunit="rad" name="copperReadoutSolid" x="60.0" y="60.0" z="0.2"/>
+        <tube lunit="mm" aunit="rad" name="cathodeTeflonDiskBaseSolid" rmax="67.0" z="5.0" rmin="15.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="cathodeCopperDiskSolid" rmax="45.0" z="1.0" rmin="8.5" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="cathodeTeflonDiskSolid">
+            <position name="cathodeTeflonDiskSolid.position" z="-2.0" unit="mm"/>
+            <first ref="cathodeTeflonDiskBaseSolid"/>
+            <second ref="cathodeCopperDiskSolid"/>
+        </subtraction>
+        <tube lunit="mm" aunit="rad" name="cathodeWindowMylarSolid" rmax="15.0" z="0.00396" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="cathodeWindowAluminiumSolid" rmax="15.0" z="4.0E-5" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <box lunit="mm" aunit="rad" name="cathodePatternLineAux" x="0.3" y="17.0" z="1.0"/>
+        <tube lunit="mm" aunit="rad" name="cathodePatternCentralHole" rmax="4.25" z="1.1" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="cathodePatternLine">
+            <first ref="cathodePatternLineAux"/>
+            <second ref="cathodePatternCentralHole"/>
+        </subtraction>
+        <tube lunit="mm" aunit="rad" name="cathodePatternDisk" rmax="4.25" z="1.0" rmin="3.95" startphi="0.0" deltaphi="6.283185307179586"/>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskSolidAux0">
+            <rotation name="cathodeCopperDiskSolidAux0.rotation" unit="deg"/>
+            <first ref="cathodeCopperDiskSolid"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskSolidAux1">
+            <rotation name="cathodeCopperDiskSolidAux1.rotation" z="45.0" unit="deg"/>
+            <first ref="cathodeCopperDiskSolidAux0"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskSolidAux2">
+            <rotation name="cathodeCopperDiskSolidAux2.rotation" z="90.0" unit="deg"/>
+            <first ref="cathodeCopperDiskSolidAux1"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskSolidAux3">
+            <rotation name="cathodeCopperDiskSolidAux3.rotation" z="135.0" unit="deg"/>
+            <first ref="cathodeCopperDiskSolidAux2"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskFinal.solid">
+            <first ref="cathodeCopperDiskSolidAux3"/>
+            <second ref="cathodePatternDisk"/>
+        </union>
+        <tube lunit="mm" aunit="rad" name="cathodeFillingBaseSolid" rmax="15.0" z="5.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="cathodeFillingSolid">
+            <position name="cathodeFillingSolid.position" z="-2.0" unit="mm"/>
+            <first ref="cathodeFillingBaseSolid"/>
+            <second ref="cathodeCopperDiskFinal.solid"/>
+        </subtraction>
+        <tube lunit="mm" aunit="rad" name="gasSolidOriginal" rmax="50.0" z="30.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidAux1">
+            <position name="gasSolidAux1.position" z="-14.9" unit="mm"/>
+            <rotation name="gasSolidAux1.rotation" z="45.0" unit="deg"/>
+            <first ref="gasSolidOriginal"/>
+            <second ref="copperReadoutSolid"/>
+        </subtraction>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidAux2">
+            <position name="gasSolidAux2.position" z="14.996020000000001" unit="mm"/>
+            <first ref="gasSolidAux1"/>
+            <second ref="cathodeWindowAluminiumSolid"/>
+        </subtraction>
+        <subtraction lunit="mm" aunit="rad" name="gasSolid">
+            <position name="gasSolid.position" z="14.99802" unit="mm"/>
+            <first ref="gasSolidAux2"/>
+            <second ref="cathodeWindowMylarSolid"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="gasSolidAboveReadoutOriginal" x="60.0" y="60.0" z="30.0"/>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidAboveReadoutAux">
+            <position name="gasSolidAboveReadoutAux.position" z="-14.9" unit="mm"/>
+            <rotation name="gasSolidAboveReadoutAux.rotation" z="45.0" unit="deg"/>
+            <first ref="gasSolidAboveReadoutOriginal"/>
+            <second ref="copperReadoutSolid"/>
+        </subtraction>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidAboveReadoutAux2">
+            <position name="gasSolidAboveReadoutAux2.position" z="14.996020000000001" unit="mm"/>
+            <first ref="gasSolidAboveReadoutAux"/>
+            <second ref="cathodeWindowAluminiumSolid"/>
+        </subtraction>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidAboveReadoutSolid">
+            <position name="gasSolidAboveReadoutSolid.position" z="14.99802" unit="mm"/>
+            <first ref="gasSolidAboveReadoutAux2"/>
+            <second ref="cathodeWindowMylarSolid"/>
+        </subtraction>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidWithHole">
+            <rotation name="gasSolidWithHole.rotation" z="45.0" unit="deg"/>
+            <first ref="gasSolid"/>
+            <second ref="gasSolidAboveReadoutSolid"/>
+        </subtraction>
+        <tube lunit="mm" aunit="rad" name="detectorPipeChamberFlangeSolid" rmax="67.0" z="14.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeTelescopeFlangeSolid" rmax="75.0" z="18.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeSection1of2Solid" rmax="46.0" z="327.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeSection2of2Solid" rmax="54.0" z="132.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <union lunit="mm" aunit="rad" name="detectorPipeAux1">
+            <position name="detectorPipeAux1.position" z="170.5" unit="mm"/>
+            <first ref="detectorPipeChamberFlangeSolid"/>
+            <second ref="detectorPipeSection1of2Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeAux2">
+            <position name="detectorPipeAux2.position" z="400.0" unit="mm"/>
+            <first ref="detectorPipeAux1"/>
+            <second ref="detectorPipeSection2of2Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeNotEmpty">
+            <position name="detectorPipeNotEmpty.position" z="475.0" unit="mm"/>
+            <first ref="detectorPipeAux2"/>
+            <second ref="detectorPipeTelescopeFlangeSolid"/>
+        </union>
+        <tube lunit="mm" aunit="rad" name="detectorPipeInside1of3Solid" rmax="21.5" z="179.35" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeInside2of3Solid" rmax="34.0" z="160.28" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeInside3of3Solid" rmax="42.5" z="106.5" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <cone lunit="mm" aunit="rad" name="detectorPipeInsideCone1of3Solid" z="21.65" rmax1="21.5" rmax2="34.0" deltaphi="6.283185307179586"/>
+        <cone lunit="mm" aunit="rad" name="detectorPipeInsideCone2of3Solid" z="14.72" rmax1="34.0" rmax2="42.5" deltaphi="6.283185307179586"/>
+        <cone lunit="mm" aunit="rad" name="detectorPipeInsideCone3of3Solid" z="8.5" rmax1="42.5" rmax2="54.0" deltaphi="6.283185307179586"/>
+        <union lunit="mm" aunit="rad" name="detectorPipeInsideAux1">
+            <position name="detectorPipeInsideAux1.position" z="100.5" unit="mm"/>
+            <first ref="detectorPipeInside1of3Solid"/>
+            <second ref="detectorPipeInsideCone1of3Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeInsideAux2">
+            <position name="detectorPipeInsideAux2.position" z="191.465" unit="mm"/>
+            <first ref="detectorPipeInsideAux1"/>
+            <second ref="detectorPipeInside2of3Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeInsideAux3">
+            <position name="detectorPipeInsideAux3.position" z="278.96500000000003" unit="mm"/>
+            <first ref="detectorPipeInsideAux2"/>
+            <second ref="detectorPipeInsideCone2of3Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeInsideAux4">
+            <position name="detectorPipeInsideAux4.position" z="339.57500000000005" unit="mm"/>
+            <first ref="detectorPipeInsideAux3"/>
+            <second ref="detectorPipeInside3of3Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeInside">
+            <position name="detectorPipeInside.position" z="397.07500000000005" unit="mm"/>
+            <first ref="detectorPipeInsideAux4"/>
+            <second ref="detectorPipeInsideCone3of3Solid"/>
+        </union>
+        <subtraction lunit="mm" aunit="rad" name="detectorPipeSolid">
+            <position name="detectorPipeSolid.position" z="82.675" unit="mm"/>
+            <first ref="detectorPipeNotEmpty"/>
+            <second ref="detectorPipeInside"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="chipSolid" x="1.0" y="25.0" z="25.0"/>
+        <box lunit="mm" aunit="rad" name="componentsSolid" x="1.0" y="40.0" z="5.0"/>
+        <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
+        <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
+        <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
+            <position name="copperBoxSolid.position" z="10.0" unit="mm"/>
+            <first ref="copperBoxOuterSolid"/>
+            <second ref="copperBoxInnerSolid"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="leadBoxSolid" x="600.0" y="600.0" z="550.0"/>
+        <box lunit="mm" aunit="rad" name="leadBoxShaftSolid" x="200.0" y="200.0" z="350.0"/>
+        <subtraction lunit="mm" aunit="rad" name="leadBoxWithShaftSolid">
+            <position name="leadBoxWithShaftSolid.position" z="100.0" unit="mm"/>
+            <first ref="leadBoxSolid"/>
+            <second ref="leadBoxShaftSolid"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="worldBox" x="1450.0" y="1600.0" z="1450.0"/>
+    </solids>
+    <structure>
+        <volume name="chamberBodyVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="chamberBodySolid"/>
+        </volume>
+        <volume name="chamberBackplateVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="chamberBackplateSolid"/>
+        </volume>
+        <volume name="chamberTeflonWallVolume">
+            <materialref ref="G4_TEFLON"/>
+            <solidref ref="chamberTeflonWallSolid"/>
+        </volume>
+        <volume name="kaptonReadoutVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="kaptonReadoutSolid"/>
+        </volume>
+        <volume name="copperReadoutVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="copperReadoutSolid"/>
+        </volume>
+        <volume name="cathodeTeflonDiskVolume">
+            <materialref ref="G4_TEFLON"/>
+            <solidref ref="cathodeTeflonDiskSolid"/>
+        </volume>
+        <volume name="cathodeWindowMylarVolume">
+            <materialref ref="G4_MYLAR"/>
+            <solidref ref="cathodeWindowMylarSolid"/>
+        </volume>
+        <volume name="cathodeWindowAluminiumVolume">
+            <materialref ref="G4_Al"/>
+            <solidref ref="cathodeWindowAluminiumSolid"/>
+        </volume>
+        <volume name="cathodeCopperDiskFinal">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="cathodeCopperDiskFinal.solid"/>
+        </volume>
+        <volume name="cathodeFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="cathodeFillingSolid"/>
+        </volume>
+        <volume name="gasVolume">
+            <materialref ref="Argon1%Isobutane1.4bar"/>
+            <solidref ref="gasSolid"/>
+        </volume>
+        <volume name="gasVolumeNotAboveReadout">
+            <materialref ref="Argon1%Isobutane1.4bar"/>
+            <solidref ref="gasSolidWithHole"/>
+        </volume>
+        <volume name="gasVolumeAboveReadout">
+            <materialref ref="Argon1%Isobutane1.4bar"/>
+            <solidref ref="gasSolidAboveReadoutSolid"/>
+        </volume>
+        <assembly name="Chamber">
+            <physvol name="gasNotAboveReadout">
+                <volumeref ref="gasVolumeNotAboveReadout"/>
+            </physvol>
+            <physvol name="gasAboveReadout">
+                <volumeref ref="gasVolumeAboveReadout"/>
+                <rotation name="gasAboveReadout.rotation" z="45.0" unit="deg"/>
+            </physvol>
+            <physvol name="chamberBackplate">
+                <volumeref ref="chamberBackplateVolume"/>
+                <position name="chamberBackplate.position" z="-23.0" unit="mm"/>
+            </physvol>
+            <physvol name="chamberBody">
+                <volumeref ref="chamberBodyVolume"/>
+            </physvol>
+            <physvol name="chamberTeflonWall">
+                <volumeref ref="chamberTeflonWallVolume"/>
+            </physvol>
+            <physvol name="kaptonReadout">
+                <volumeref ref="kaptonReadoutVolume"/>
+                <position name="kaptonReadout.position" z="-15.25" unit="mm"/>
+            </physvol>
+            <physvol name="copperReadout">
+                <volumeref ref="copperReadoutVolume"/>
+                <position name="copperReadout.position" z="-14.9" unit="mm"/>
+                <rotation name="copperReadout.rotation" z="45.0" unit="deg"/>
+            </physvol>
+            <physvol name="cathodeWindowMylar">
+                <volumeref ref="cathodeWindowMylarVolume"/>
+                <position name="cathodeWindowMylar.position" z="14.99802" unit="mm"/>
+            </physvol>
+            <physvol name="cathodeWindowAluminium">
+                <volumeref ref="cathodeWindowAluminiumVolume"/>
+                <position name="cathodeWindowAluminium.position" z="14.996020000000001" unit="mm"/>
+            </physvol>
+            <physvol name="cathodeTeflonDisk">
+                <volumeref ref="cathodeTeflonDiskVolume"/>
+                <position name="cathodeTeflonDisk.position" z="17.5" unit="mm"/>
+            </physvol>
+            <physvol name="cathodeFilling">
+                <volumeref ref="cathodeFillingVolume"/>
+                <position name="cathodeFilling.position" z="17.5" unit="mm"/>
+            </physvol>
+            <physvol name="cathodeCopperDiskPattern">
+                <volumeref ref="cathodeCopperDiskFinal"/>
+                <position name="cathodeCopperDiskPattern.position" z="15.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="detectorPipeVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="detectorPipeSolid"/>
+        </volume>
+        <volume name="detectorPipeFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="detectorPipeInside"/>
+        </volume>
+        <assembly name="detectorPipe">
+            <physvol name="detectorPipe">
+                <volumeref ref="detectorPipeVolume"/>
+            </physvol>
+            <physvol name="detectorPipeFilling">
+                <volumeref ref="detectorPipeFillingVolume"/>
+                <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatCableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatCableSolid"/>
+        </volume>
+        <volume name="chipVolume">
+            <materialref ref="G4_Si"/>
+            <solidref ref="chipSolid"/>
+        </volume>
+        <volume name="componentsVolume">
+            <materialref ref="G4_Si"/>
+            <solidref ref="componentsSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="chip1">
+                <volumeref ref="chipVolume"/>
+                <position name="chip1.position" x="-13.25" unit="mm"/>
+            </physvol>
+            <physvol name="chip2">
+                <volumeref ref="chipVolume"/>
+                <position name="chip2.position" x="-3.25" unit="mm"/>
+            </physvol>
+            <physvol name="chip3">
+                <volumeref ref="chipVolume"/>
+                <position name="chip3.position" x="6.75" unit="mm"/>
+            </physvol>
+            <physvol name="chip4">
+                <volumeref ref="chipVolume"/>
+                <position name="chip4.position" x="16.75" unit="mm"/>
+            </physvol>
+            <physvol name="components1">
+                <volumeref ref="componentsVolume"/>
+                <position name="components1.position" x="-13.25" z="-30.0" unit="mm"/>
+            </physvol>
+            <physvol name="components2">
+                <volumeref ref="componentsVolume"/>
+                <position name="components2.position" x="-3.25" z="-30.0" unit="mm"/>
+            </physvol>
+            <physvol name="components3">
+                <volumeref ref="componentsVolume"/>
+                <position name="components3.position" x="6.75" z="-30.0" unit="mm"/>
+            </physvol>
+            <physvol name="components4">
+                <volumeref ref="componentsVolume"/>
+                <position name="components4.position" x="16.75" z="-30.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatCable1">
+                <volumeref ref="flatCableVolume"/>
+                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatCable2">
+                <volumeref ref="flatCableVolume"/>
+                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatCable3">
+                <volumeref ref="flatCableVolume"/>
+                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatCable4">
+                <volumeref ref="flatCableVolume"/>
+                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="copperBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="copperBoxSolid"/>
+        </volume>
+        <volume name="shieldingVolume">
+            <materialref ref="G4_Pb"/>
+            <solidref ref="leadBoxWithShaftSolid"/>
+        </volume>
+        <assembly name="shielding">
+            <physvol name="shieldingLead">
+                <volumeref ref="shieldingVolume"/>
+                <position name="shieldingLead.position" z="19.5" unit="mm"/>
+            </physvol>
+            <physvol name="copperBox">
+                <volumeref ref="copperBoxVolume"/>
+                <position name="copperBox.position" z="119.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="world">
+            <physvol name="Chamber">
+                <volumeref ref="Chamber"/>
+            </physvol>
+            <physvol name="DetectorPipe">
+                <volumeref ref="detectorPipe"/>
+                <position name="DetectorPipe.position" z="27.0" unit="mm"/>
+            </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
+            </physvol>
+            <physvol name="Shielding">
+                <volumeref ref="shielding"/>
+            </physvol>
+            <materialref ref="G4_AIR"/>
+            <solidref ref="worldBox"/>
+        </volume>
+    </structure>
+    <setup name="Default" version="1.0">
+        <world ref="world"/>
+    </setup>
+</gdml>

--- a/gdml/BabyIAXO/NoVetoesGasNotSplit.gdml
+++ b/gdml/BabyIAXO/NoVetoesGasNotSplit.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4283,46 +4283,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/BabyIAXO/ShieldingLayers.gdml
+++ b/gdml/BabyIAXO/ShieldingLayers.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerBox1" x="220.0" y="220.0" z="360.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerHole1" x="200.0" y="200.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="shieldingLayerBoxWithHole1">
@@ -4420,46 +4420,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="shieldingVolumeLayer1">

--- a/gdml/BabyIAXO/ShieldingLayersNoCopperBox.gdml
+++ b/gdml/BabyIAXO/ShieldingLayersNoCopperBox.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerBox1" x="220.0" y="220.0" z="360.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerHole1" x="200.0" y="200.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="shieldingLayerBoxWithHole1">
@@ -4420,46 +4420,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="shieldingVolumeLayer1">

--- a/gdml/BabyIAXO/WithTelescopePipe.gdml
+++ b/gdml/BabyIAXO/WithTelescopePipe.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4336,46 +4336,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/IAXO-D1/ChamberAndPipe.gdml
+++ b/gdml/IAXO-D1/ChamberAndPipe.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="worldBox" x="1350.0" y="1350.0" z="3000.0"/>
     </solids>
     <structure>
@@ -4273,46 +4273,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="world">

--- a/gdml/IAXO-D1/CompleteVeto1Layers.gdml
+++ b/gdml/IAXO-D1/CompleteVeto1Layers.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4328,46 +4328,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/IAXO-D1/CompleteVeto2Layers.gdml
+++ b/gdml/IAXO-D1/CompleteVeto2Layers.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4328,46 +4328,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/IAXO-D1/CompleteVeto3Layers.gdml
+++ b/gdml/IAXO-D1/CompleteVeto3Layers.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4328,46 +4328,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/IAXO-D1/CompleteVeto4Layers.gdml
+++ b/gdml/IAXO-D1/CompleteVeto4Layers.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4328,46 +4328,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/IAXO-D1/Default.gdml
+++ b/gdml/IAXO-D1/Default.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4328,46 +4328,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/IAXO-D1/DefaultXenon.gdml
+++ b/gdml/IAXO-D1/DefaultXenon.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4328,46 +4328,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/IAXO-D1/NoVetoes.gdml
+++ b/gdml/IAXO-D1/NoVetoes.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4287,46 +4287,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/IAXO-D1/NoVetoesDetailedElectronics.gdml
+++ b/gdml/IAXO-D1/NoVetoesDetailedElectronics.gdml
@@ -4143,10 +4143,10 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
-        <box lunit="mm" aunit="rad" name="chipSolid" x="1.0" y="25.0" z="25.0"/>
-        <box lunit="mm" aunit="rad" name="componentsSolid" x="1.0" y="40.0" z="5.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
+        <box lunit="mm" aunit="rad" name="chipSolid" x="1.0" y="28.0" z="28.0"/>
+        <box lunit="mm" aunit="rad" name="componentsSolid" x="1.0" y="76.2" z="9.3"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4289,13 +4289,21 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <volume name="chipVolume">
             <materialref ref="G4_Si"/>
@@ -4306,69 +4314,101 @@
             <solidref ref="componentsSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
             <physvol name="chip1">
                 <volumeref ref="chipVolume"/>
-                <position name="chip1.position" x="-13.25" unit="mm"/>
-            </physvol>
-            <physvol name="chip2">
-                <volumeref ref="chipVolume"/>
-                <position name="chip2.position" x="-3.25" unit="mm"/>
-            </physvol>
-            <physvol name="chip3">
-                <volumeref ref="chipVolume"/>
-                <position name="chip3.position" x="6.75" unit="mm"/>
-            </physvol>
-            <physvol name="chip4">
-                <volumeref ref="chipVolume"/>
-                <position name="chip4.position" x="16.75" unit="mm"/>
+                <position name="chip1.position" x="-14.19" z="38.1" unit="mm"/>
             </physvol>
             <physvol name="components1">
                 <volumeref ref="componentsVolume"/>
-                <position name="components1.position" x="-13.25" z="-30.0" unit="mm"/>
+                <position name="components1.position" x="-14.19" z="-38.1" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="chip2">
+                <volumeref ref="chipVolume"/>
+                <position name="chip2.position" x="-4.19" z="38.1" unit="mm"/>
             </physvol>
             <physvol name="components2">
                 <volumeref ref="componentsVolume"/>
-                <position name="components2.position" x="-3.25" z="-30.0" unit="mm"/>
+                <position name="components2.position" x="-4.19" z="-38.1" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="chip3">
+                <volumeref ref="chipVolume"/>
+                <position name="chip3.position" x="5.81" z="38.1" unit="mm"/>
             </physvol>
             <physvol name="components3">
                 <volumeref ref="componentsVolume"/>
-                <position name="components3.position" x="6.75" z="-30.0" unit="mm"/>
+                <position name="components3.position" x="5.81" z="-38.1" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="chip4">
+                <volumeref ref="chipVolume"/>
+                <position name="chip4.position" x="15.81" z="38.1" unit="mm"/>
             </physvol>
             <physvol name="components4">
                 <volumeref ref="componentsVolume"/>
-                <position name="components4.position" x="16.75" z="-30.0" unit="mm"/>
-            </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
-            </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
-            </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
-            </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+                <position name="components4.position" x="15.81" z="-38.1" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/IAXO-D1/NoVetoesDetailedElectronics.gdml
+++ b/gdml/IAXO-D1/NoVetoesDetailedElectronics.gdml
@@ -1,0 +1,4414 @@
+<?xml version='1.0'?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+    <define/>
+    <materials>
+        <isotope Z="1.0" N="1" name="H1">
+            <atom value="1.007825" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="1.0" N="2" name="H2">
+            <atom value="2.014102" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="H">
+            <fraction n="0.999885" ref="H1"/>
+            <fraction n="1.15E-4" ref="H2"/>
+        </element>
+        <isotope Z="2.0" N="3" name="He3">
+            <atom value="3.01693" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="2.0" N="4" name="He4">
+            <atom value="4.002644" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="He">
+            <fraction n="1.0E-6" ref="He3"/>
+            <fraction n="0.999999" ref="He4"/>
+        </element>
+        <isotope Z="3.0" N="6" name="Li6">
+            <atom value="6.01512" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="3.0" N="7" name="Li7">
+            <atom value="7.016" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Li">
+            <fraction n="0.0759" ref="Li6"/>
+            <fraction n="0.9241" ref="Li7"/>
+        </element>
+        <isotope Z="4.0" N="9" name="Be9">
+            <atom value="9.01218" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Be">
+            <fraction n="1.0" ref="Be9"/>
+        </element>
+        <isotope Z="5.0" N="10" name="B10">
+            <atom value="10.0129" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="5.0" N="11" name="B11">
+            <atom value="11.0093" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="B">
+            <fraction n="0.199" ref="B10"/>
+            <fraction n="0.801" ref="B11"/>
+        </element>
+        <isotope Z="6.0" N="12" name="C12">
+            <atom value="12.0" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="6.0" N="13" name="C13">
+            <atom value="13.0034" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="C">
+            <fraction n="0.9893" ref="C12"/>
+            <fraction n="0.0107" ref="C13"/>
+        </element>
+        <isotope Z="7.0" N="14" name="N14">
+            <atom value="14.0031" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="7.0" N="15" name="N15">
+            <atom value="15.0001" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="N">
+            <fraction n="0.99632" ref="N14"/>
+            <fraction n="0.00368" ref="N15"/>
+        </element>
+        <isotope Z="8.0" N="16" name="O16">
+            <atom value="15.9949" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="8.0" N="17" name="O17">
+            <atom value="16.9991" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="8.0" N="18" name="O18">
+            <atom value="17.9992" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="O">
+            <fraction n="0.99757" ref="O16"/>
+            <fraction n="3.8E-4" ref="O17"/>
+            <fraction n="0.00205" ref="O18"/>
+        </element>
+        <isotope Z="9.0" N="19" name="F19">
+            <atom value="18.9984" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="F">
+            <fraction n="1.0" ref="F19"/>
+        </element>
+        <isotope Z="10.0" N="20" name="Ne20">
+            <atom value="19.9924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="10.0" N="21" name="Ne21">
+            <atom value="20.9938" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="10.0" N="22" name="Ne22">
+            <atom value="21.9914" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ne">
+            <fraction n="0.9048" ref="Ne20"/>
+            <fraction n="0.0027" ref="Ne21"/>
+            <fraction n="0.0925" ref="Ne22"/>
+        </element>
+        <isotope Z="11.0" N="23" name="Na23">
+            <atom value="22.9898" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Na">
+            <fraction n="1.0" ref="Na23"/>
+        </element>
+        <isotope Z="12.0" N="24" name="Mg24">
+            <atom value="23.985" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="12.0" N="25" name="Mg25">
+            <atom value="24.9858" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="12.0" N="26" name="Mg26">
+            <atom value="25.9826" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Mg">
+            <fraction n="0.7899" ref="Mg24"/>
+            <fraction n="0.1" ref="Mg25"/>
+            <fraction n="0.1101" ref="Mg26"/>
+        </element>
+        <isotope Z="13.0" N="27" name="Al27">
+            <atom value="26.9815" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Al">
+            <fraction n="1.0" ref="Al27"/>
+        </element>
+        <isotope Z="14.0" N="28" name="Si28">
+            <atom value="27.9769" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="14.0" N="29" name="Si29">
+            <atom value="28.9765" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="14.0" N="30" name="Si30">
+            <atom value="29.9738" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Si">
+            <fraction n="0.922296" ref="Si28"/>
+            <fraction n="0.046832" ref="Si29"/>
+            <fraction n="0.030872" ref="Si30"/>
+        </element>
+        <isotope Z="15.0" N="31" name="P31">
+            <atom value="30.9738" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="P">
+            <fraction n="1.0" ref="P31"/>
+        </element>
+        <isotope Z="16.0" N="32" name="S32">
+            <atom value="31.9721" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="16.0" N="33" name="S33">
+            <atom value="32.9715" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="16.0" N="34" name="S34">
+            <atom value="33.9679" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="16.0" N="36" name="S36">
+            <atom value="35.9671" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="S">
+            <fraction n="0.9493" ref="S32"/>
+            <fraction n="0.0076" ref="S33"/>
+            <fraction n="0.0429" ref="S34"/>
+            <fraction n="2.0E-4" ref="S36"/>
+        </element>
+        <isotope Z="17.0" N="35" name="Cl35">
+            <atom value="34.9689" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="17.0" N="37" name="Cl37">
+            <atom value="36.9659" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cl">
+            <fraction n="0.7578" ref="Cl35"/>
+            <fraction n="0.2422" ref="Cl37"/>
+        </element>
+        <isotope Z="18.0" N="36" name="Ar36">
+            <atom value="35.9675" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="18.0" N="38" name="Ar38">
+            <atom value="37.9627" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="18.0" N="40" name="Ar40">
+            <atom value="39.9624" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ar">
+            <fraction n="0.003365" ref="Ar36"/>
+            <fraction n="6.32E-4" ref="Ar38"/>
+            <fraction n="0.996003" ref="Ar40"/>
+        </element>
+        <isotope Z="19.0" N="39" name="K39">
+            <atom value="38.9637" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="19.0" N="40" name="K40">
+            <atom value="39.964" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="19.0" N="41" name="K41">
+            <atom value="40.9618" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="K">
+            <fraction n="0.932581" ref="K39"/>
+            <fraction n="1.17E-4" ref="K40"/>
+            <fraction n="0.067302" ref="K41"/>
+        </element>
+        <isotope Z="20.0" N="40" name="Ca40">
+            <atom value="39.9626" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="42" name="Ca42">
+            <atom value="41.9586" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="43" name="Ca43">
+            <atom value="42.9588" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="44" name="Ca44">
+            <atom value="43.9555" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="46" name="Ca46">
+            <atom value="45.9537" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="48" name="Ca48">
+            <atom value="47.9525" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ca">
+            <fraction n="0.96941" ref="Ca40"/>
+            <fraction n="0.00647" ref="Ca42"/>
+            <fraction n="0.00135" ref="Ca43"/>
+            <fraction n="0.02086" ref="Ca44"/>
+            <fraction n="4.0E-5" ref="Ca46"/>
+            <fraction n="0.00187" ref="Ca48"/>
+        </element>
+        <isotope Z="21.0" N="45" name="Sc45">
+            <atom value="44.9559" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sc">
+            <fraction n="1.0" ref="Sc45"/>
+        </element>
+        <isotope Z="22.0" N="46" name="Ti46">
+            <atom value="45.9526" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="22.0" N="47" name="Ti47">
+            <atom value="46.9518" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="22.0" N="48" name="Ti48">
+            <atom value="47.9479" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="22.0" N="49" name="Ti49">
+            <atom value="48.9479" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="22.0" N="50" name="Ti50">
+            <atom value="49.9448" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ti">
+            <fraction n="0.0825" ref="Ti46"/>
+            <fraction n="0.0744" ref="Ti47"/>
+            <fraction n="0.7372" ref="Ti48"/>
+            <fraction n="0.0541" ref="Ti49"/>
+            <fraction n="0.0518" ref="Ti50"/>
+        </element>
+        <isotope Z="23.0" N="50" name="V50">
+            <atom value="49.9472" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="23.0" N="51" name="V51">
+            <atom value="50.944" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="V">
+            <fraction n="0.0025" ref="V50"/>
+            <fraction n="0.9975" ref="V51"/>
+        </element>
+        <isotope Z="24.0" N="50" name="Cr50">
+            <atom value="49.946" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="24.0" N="52" name="Cr52">
+            <atom value="51.9405" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="24.0" N="53" name="Cr53">
+            <atom value="52.9407" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="24.0" N="54" name="Cr54">
+            <atom value="53.9389" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cr">
+            <fraction n="0.04345" ref="Cr50"/>
+            <fraction n="0.83789" ref="Cr52"/>
+            <fraction n="0.09501" ref="Cr53"/>
+            <fraction n="0.02365" ref="Cr54"/>
+        </element>
+        <isotope Z="25.0" N="55" name="Mn55">
+            <atom value="54.938" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Mn">
+            <fraction n="1.0" ref="Mn55"/>
+        </element>
+        <isotope Z="26.0" N="54" name="Fe54">
+            <atom value="53.9396" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="26.0" N="56" name="Fe56">
+            <atom value="55.9349" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="26.0" N="57" name="Fe57">
+            <atom value="56.9354" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="26.0" N="58" name="Fe58">
+            <atom value="57.9333" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Fe">
+            <fraction n="0.05845" ref="Fe54"/>
+            <fraction n="0.91754" ref="Fe56"/>
+            <fraction n="0.02119" ref="Fe57"/>
+            <fraction n="0.00282" ref="Fe58"/>
+        </element>
+        <isotope Z="27.0" N="59" name="Co59">
+            <atom value="58.9332" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Co">
+            <fraction n="1.0" ref="Co59"/>
+        </element>
+        <isotope Z="28.0" N="58" name="Ni58">
+            <atom value="57.9353" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="28.0" N="60" name="Ni60">
+            <atom value="59.9308" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="28.0" N="61" name="Ni61">
+            <atom value="60.9311" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="28.0" N="62" name="Ni62">
+            <atom value="61.9283" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="28.0" N="64" name="Ni64">
+            <atom value="63.928" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ni">
+            <fraction n="0.680769" ref="Ni58"/>
+            <fraction n="0.262231" ref="Ni60"/>
+            <fraction n="0.011399" ref="Ni61"/>
+            <fraction n="0.036345" ref="Ni62"/>
+            <fraction n="0.009256" ref="Ni64"/>
+        </element>
+        <isotope Z="29.0" N="63" name="Cu63">
+            <atom value="62.9296" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="29.0" N="65" name="Cu65">
+            <atom value="64.9278" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cu">
+            <fraction n="0.6917" ref="Cu63"/>
+            <fraction n="0.3083" ref="Cu65"/>
+        </element>
+        <isotope Z="30.0" N="64" name="Zn64">
+            <atom value="63.9291" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="30.0" N="66" name="Zn66">
+            <atom value="65.926" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="30.0" N="67" name="Zn67">
+            <atom value="66.9271" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="30.0" N="68" name="Zn68">
+            <atom value="67.9248" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="30.0" N="70" name="Zn70">
+            <atom value="69.9253" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Zn">
+            <fraction n="0.4863" ref="Zn64"/>
+            <fraction n="0.279" ref="Zn66"/>
+            <fraction n="0.041" ref="Zn67"/>
+            <fraction n="0.1875" ref="Zn68"/>
+            <fraction n="0.0062" ref="Zn70"/>
+        </element>
+        <isotope Z="31.0" N="69" name="Ga69">
+            <atom value="68.9256" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="31.0" N="71" name="Ga71">
+            <atom value="70.9247" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ga">
+            <fraction n="0.60108" ref="Ga69"/>
+            <fraction n="0.39892" ref="Ga71"/>
+        </element>
+        <isotope Z="32.0" N="70" name="Ge70">
+            <atom value="69.9243" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="32.0" N="72" name="Ge72">
+            <atom value="71.9221" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="32.0" N="73" name="Ge73">
+            <atom value="72.9235" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="32.0" N="74" name="Ge74">
+            <atom value="73.9212" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="32.0" N="76" name="Ge76">
+            <atom value="75.9214" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ge">
+            <fraction n="0.2084" ref="Ge70"/>
+            <fraction n="0.2754" ref="Ge72"/>
+            <fraction n="0.0773" ref="Ge73"/>
+            <fraction n="0.3628" ref="Ge74"/>
+            <fraction n="0.0761" ref="Ge76"/>
+        </element>
+        <isotope Z="33.0" N="75" name="As75">
+            <atom value="74.9216" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="As">
+            <fraction n="1.0" ref="As75"/>
+        </element>
+        <isotope Z="34.0" N="74" name="Se74">
+            <atom value="73.9225" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="76" name="Se76">
+            <atom value="75.9192" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="77" name="Se77">
+            <atom value="76.9199" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="78" name="Se78">
+            <atom value="77.9173" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="80" name="Se80">
+            <atom value="79.9165" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="82" name="Se82">
+            <atom value="81.9167" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Se">
+            <fraction n="0.0089" ref="Se74"/>
+            <fraction n="0.0937" ref="Se76"/>
+            <fraction n="0.0763" ref="Se77"/>
+            <fraction n="0.2377" ref="Se78"/>
+            <fraction n="0.4961" ref="Se80"/>
+            <fraction n="0.0873" ref="Se82"/>
+        </element>
+        <isotope Z="35.0" N="79" name="Br79">
+            <atom value="78.9183" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="35.0" N="81" name="Br81">
+            <atom value="80.9163" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Br">
+            <fraction n="0.5069" ref="Br79"/>
+            <fraction n="0.4931" ref="Br81"/>
+        </element>
+        <isotope Z="36.0" N="78" name="Kr78">
+            <atom value="77.9204" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="80" name="Kr80">
+            <atom value="79.9164" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="82" name="Kr82">
+            <atom value="81.9135" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="83" name="Kr83">
+            <atom value="82.9141" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="84" name="Kr84">
+            <atom value="83.9115" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="86" name="Kr86">
+            <atom value="85.9106" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Kr">
+            <fraction n="0.0035" ref="Kr78"/>
+            <fraction n="0.0228" ref="Kr80"/>
+            <fraction n="0.1158" ref="Kr82"/>
+            <fraction n="0.1149" ref="Kr83"/>
+            <fraction n="0.57" ref="Kr84"/>
+            <fraction n="0.173" ref="Kr86"/>
+        </element>
+        <isotope Z="37.0" N="85" name="Rb85">
+            <atom value="84.9118" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="37.0" N="87" name="Rb87">
+            <atom value="86.9092" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Rb">
+            <fraction n="0.7217" ref="Rb85"/>
+            <fraction n="0.2783" ref="Rb87"/>
+        </element>
+        <isotope Z="38.0" N="84" name="Sr84">
+            <atom value="83.9134" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="38.0" N="86" name="Sr86">
+            <atom value="85.9093" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="38.0" N="87" name="Sr87">
+            <atom value="86.9089" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="38.0" N="88" name="Sr88">
+            <atom value="87.9056" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sr">
+            <fraction n="0.0056" ref="Sr84"/>
+            <fraction n="0.0986" ref="Sr86"/>
+            <fraction n="0.07" ref="Sr87"/>
+            <fraction n="0.8258" ref="Sr88"/>
+        </element>
+        <isotope Z="39.0" N="89" name="Y89">
+            <atom value="88.9058" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Y">
+            <fraction n="1.0" ref="Y89"/>
+        </element>
+        <isotope Z="40.0" N="90" name="Zr90">
+            <atom value="89.9047" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="40.0" N="91" name="Zr91">
+            <atom value="90.9056" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="40.0" N="92" name="Zr92">
+            <atom value="91.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="40.0" N="94" name="Zr94">
+            <atom value="93.9063" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="40.0" N="96" name="Zr96">
+            <atom value="95.9083" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Zr">
+            <fraction n="0.5145" ref="Zr90"/>
+            <fraction n="0.1122" ref="Zr91"/>
+            <fraction n="0.1715" ref="Zr92"/>
+            <fraction n="0.1738" ref="Zr94"/>
+            <fraction n="0.028" ref="Zr96"/>
+        </element>
+        <isotope Z="41.0" N="93" name="Nb93">
+            <atom value="92.9064" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Nb">
+            <fraction n="1.0" ref="Nb93"/>
+        </element>
+        <isotope Z="42.0" N="92" name="Mo92">
+            <atom value="91.9068" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="94" name="Mo94">
+            <atom value="93.9051" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="95" name="Mo95">
+            <atom value="94.9058" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="96" name="Mo96">
+            <atom value="95.9047" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="97" name="Mo97">
+            <atom value="96.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="98" name="Mo98">
+            <atom value="97.9054" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="100" name="Mo100">
+            <atom value="99.9075" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Mo">
+            <fraction n="0.1484" ref="Mo92"/>
+            <fraction n="0.0925" ref="Mo94"/>
+            <fraction n="0.1592" ref="Mo95"/>
+            <fraction n="0.1668" ref="Mo96"/>
+            <fraction n="0.0955" ref="Mo97"/>
+            <fraction n="0.2413" ref="Mo98"/>
+            <fraction n="0.0963" ref="Mo100"/>
+        </element>
+        <isotope Z="43.0" N="98" name="Tc98">
+            <atom value="97.9072" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Tc">
+            <fraction n="1.0" ref="Tc98"/>
+        </element>
+        <isotope Z="44.0" N="96" name="Ru96">
+            <atom value="95.9076" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="98" name="Ru98">
+            <atom value="97.9053" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="99" name="Ru99">
+            <atom value="98.9059" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="100" name="Ru100">
+            <atom value="99.9042" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="101" name="Ru101">
+            <atom value="100.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="102" name="Ru102">
+            <atom value="101.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="104" name="Ru104">
+            <atom value="103.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ru">
+            <fraction n="0.0554" ref="Ru96"/>
+            <fraction n="0.0187" ref="Ru98"/>
+            <fraction n="0.1276" ref="Ru99"/>
+            <fraction n="0.126" ref="Ru100"/>
+            <fraction n="0.1706" ref="Ru101"/>
+            <fraction n="0.3155" ref="Ru102"/>
+            <fraction n="0.1862" ref="Ru104"/>
+        </element>
+        <isotope Z="45.0" N="103" name="Rh103">
+            <atom value="102.906" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Rh">
+            <fraction n="1.0" ref="Rh103"/>
+        </element>
+        <isotope Z="46.0" N="102" name="Pd102">
+            <atom value="101.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="104" name="Pd104">
+            <atom value="103.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="105" name="Pd105">
+            <atom value="104.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="106" name="Pd106">
+            <atom value="105.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="108" name="Pd108">
+            <atom value="107.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="110" name="Pd110">
+            <atom value="109.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pd">
+            <fraction n="0.0102" ref="Pd102"/>
+            <fraction n="0.1114" ref="Pd104"/>
+            <fraction n="0.2233" ref="Pd105"/>
+            <fraction n="0.2733" ref="Pd106"/>
+            <fraction n="0.2646" ref="Pd108"/>
+            <fraction n="0.1172" ref="Pd110"/>
+        </element>
+        <isotope Z="47.0" N="107" name="Ag107">
+            <atom value="106.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="47.0" N="109" name="Ag109">
+            <atom value="108.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ag">
+            <fraction n="0.51839" ref="Ag107"/>
+            <fraction n="0.48161" ref="Ag109"/>
+        </element>
+        <isotope Z="48.0" N="106" name="Cd106">
+            <atom value="105.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="108" name="Cd108">
+            <atom value="107.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="110" name="Cd110">
+            <atom value="109.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="111" name="Cd111">
+            <atom value="110.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="112" name="Cd112">
+            <atom value="111.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="113" name="Cd113">
+            <atom value="112.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="114" name="Cd114">
+            <atom value="113.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="116" name="Cd116">
+            <atom value="115.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cd">
+            <fraction n="0.0125" ref="Cd106"/>
+            <fraction n="0.0089" ref="Cd108"/>
+            <fraction n="0.1249" ref="Cd110"/>
+            <fraction n="0.128" ref="Cd111"/>
+            <fraction n="0.2413" ref="Cd112"/>
+            <fraction n="0.1222" ref="Cd113"/>
+            <fraction n="0.2873" ref="Cd114"/>
+            <fraction n="0.0749" ref="Cd116"/>
+        </element>
+        <isotope Z="49.0" N="113" name="In113">
+            <atom value="112.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="49.0" N="115" name="In115">
+            <atom value="114.904" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="In">
+            <fraction n="0.0429" ref="In113"/>
+            <fraction n="0.9571" ref="In115"/>
+        </element>
+        <isotope Z="50.0" N="112" name="Sn112">
+            <atom value="111.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="114" name="Sn114">
+            <atom value="113.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="115" name="Sn115">
+            <atom value="114.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="116" name="Sn116">
+            <atom value="115.902" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="117" name="Sn117">
+            <atom value="116.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="118" name="Sn118">
+            <atom value="117.902" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="119" name="Sn119">
+            <atom value="118.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="120" name="Sn120">
+            <atom value="119.902" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="122" name="Sn122">
+            <atom value="121.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="124" name="Sn124">
+            <atom value="123.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sn">
+            <fraction n="0.0097" ref="Sn112"/>
+            <fraction n="0.0066" ref="Sn114"/>
+            <fraction n="0.0034" ref="Sn115"/>
+            <fraction n="0.1454" ref="Sn116"/>
+            <fraction n="0.0768" ref="Sn117"/>
+            <fraction n="0.2422" ref="Sn118"/>
+            <fraction n="0.0859" ref="Sn119"/>
+            <fraction n="0.3258" ref="Sn120"/>
+            <fraction n="0.0463" ref="Sn122"/>
+            <fraction n="0.0579" ref="Sn124"/>
+        </element>
+        <isotope Z="51.0" N="121" name="Sb121">
+            <atom value="120.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="51.0" N="123" name="Sb123">
+            <atom value="122.904" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sb">
+            <fraction n="0.5721" ref="Sb121"/>
+            <fraction n="0.4279" ref="Sb123"/>
+        </element>
+        <isotope Z="52.0" N="120" name="Te120">
+            <atom value="119.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="122" name="Te122">
+            <atom value="121.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="123" name="Te123">
+            <atom value="122.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="124" name="Te124">
+            <atom value="123.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="125" name="Te125">
+            <atom value="124.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="126" name="Te126">
+            <atom value="125.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="128" name="Te128">
+            <atom value="127.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="130" name="Te130">
+            <atom value="129.906" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Te">
+            <fraction n="9.0E-4" ref="Te120"/>
+            <fraction n="0.0255" ref="Te122"/>
+            <fraction n="0.0089" ref="Te123"/>
+            <fraction n="0.0474" ref="Te124"/>
+            <fraction n="0.0707" ref="Te125"/>
+            <fraction n="0.1884" ref="Te126"/>
+            <fraction n="0.3174" ref="Te128"/>
+            <fraction n="0.3408" ref="Te130"/>
+        </element>
+        <isotope Z="53.0" N="127" name="I127">
+            <atom value="126.904" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="I">
+            <fraction n="1.0" ref="I127"/>
+        </element>
+        <isotope Z="54.0" N="124" name="Xe124">
+            <atom value="123.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="126" name="Xe126">
+            <atom value="125.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="128" name="Xe128">
+            <atom value="127.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="129" name="Xe129">
+            <atom value="128.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="130" name="Xe130">
+            <atom value="129.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="131" name="Xe131">
+            <atom value="130.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="132" name="Xe132">
+            <atom value="131.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="134" name="Xe134">
+            <atom value="133.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="136" name="Xe136">
+            <atom value="135.907" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Xe">
+            <fraction n="9.0E-4" ref="Xe124"/>
+            <fraction n="9.0E-4" ref="Xe126"/>
+            <fraction n="0.0192" ref="Xe128"/>
+            <fraction n="0.2644" ref="Xe129"/>
+            <fraction n="0.0408" ref="Xe130"/>
+            <fraction n="0.2118" ref="Xe131"/>
+            <fraction n="0.2689" ref="Xe132"/>
+            <fraction n="0.1044" ref="Xe134"/>
+            <fraction n="0.0887" ref="Xe136"/>
+        </element>
+        <isotope Z="55.0" N="133" name="Cs133">
+            <atom value="132.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cs">
+            <fraction n="1.0" ref="Cs133"/>
+        </element>
+        <isotope Z="56.0" N="130" name="Ba130">
+            <atom value="129.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="132" name="Ba132">
+            <atom value="131.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="134" name="Ba134">
+            <atom value="133.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="135" name="Ba135">
+            <atom value="134.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="136" name="Ba136">
+            <atom value="135.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="137" name="Ba137">
+            <atom value="136.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="138" name="Ba138">
+            <atom value="137.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ba">
+            <fraction n="0.00106" ref="Ba130"/>
+            <fraction n="0.00101" ref="Ba132"/>
+            <fraction n="0.02417" ref="Ba134"/>
+            <fraction n="0.06592" ref="Ba135"/>
+            <fraction n="0.07854" ref="Ba136"/>
+            <fraction n="0.11232" ref="Ba137"/>
+            <fraction n="0.71698" ref="Ba138"/>
+        </element>
+        <isotope Z="57.0" N="138" name="La138">
+            <atom value="137.907" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="57.0" N="139" name="La139">
+            <atom value="138.906" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="La">
+            <fraction n="9.0E-4" ref="La138"/>
+            <fraction n="0.9991" ref="La139"/>
+        </element>
+        <isotope Z="58.0" N="136" name="Ce136">
+            <atom value="135.907" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="58.0" N="138" name="Ce138">
+            <atom value="137.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="58.0" N="140" name="Ce140">
+            <atom value="139.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="58.0" N="142" name="Ce142">
+            <atom value="141.909" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ce">
+            <fraction n="0.00185" ref="Ce136"/>
+            <fraction n="0.00251" ref="Ce138"/>
+            <fraction n="0.8845" ref="Ce140"/>
+            <fraction n="0.11114" ref="Ce142"/>
+        </element>
+        <isotope Z="59.0" N="141" name="Pr141">
+            <atom value="140.908" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pr">
+            <fraction n="1.0" ref="Pr141"/>
+        </element>
+        <isotope Z="60.0" N="142" name="Nd142">
+            <atom value="141.908" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="143" name="Nd143">
+            <atom value="142.91" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="144" name="Nd144">
+            <atom value="143.91" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="145" name="Nd145">
+            <atom value="144.913" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="146" name="Nd146">
+            <atom value="145.913" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="148" name="Nd148">
+            <atom value="147.917" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="150" name="Nd150">
+            <atom value="149.921" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Nd">
+            <fraction n="0.272" ref="Nd142"/>
+            <fraction n="0.122" ref="Nd143"/>
+            <fraction n="0.238" ref="Nd144"/>
+            <fraction n="0.083" ref="Nd145"/>
+            <fraction n="0.172" ref="Nd146"/>
+            <fraction n="0.057" ref="Nd148"/>
+            <fraction n="0.056" ref="Nd150"/>
+        </element>
+        <isotope Z="61.0" N="145" name="Pm145">
+            <atom value="144.913" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pm">
+            <fraction n="1.0" ref="Pm145"/>
+        </element>
+        <isotope Z="62.0" N="144" name="Sm144">
+            <atom value="143.912" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="147" name="Sm147">
+            <atom value="146.915" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="148" name="Sm148">
+            <atom value="147.915" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="149" name="Sm149">
+            <atom value="148.917" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="150" name="Sm150">
+            <atom value="149.917" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="152" name="Sm152">
+            <atom value="151.92" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="154" name="Sm154">
+            <atom value="153.922" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sm">
+            <fraction n="0.0307" ref="Sm144"/>
+            <fraction n="0.1499" ref="Sm147"/>
+            <fraction n="0.1124" ref="Sm148"/>
+            <fraction n="0.1382" ref="Sm149"/>
+            <fraction n="0.0738" ref="Sm150"/>
+            <fraction n="0.2675" ref="Sm152"/>
+            <fraction n="0.2275" ref="Sm154"/>
+        </element>
+        <isotope Z="63.0" N="151" name="Eu151">
+            <atom value="150.92" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="63.0" N="153" name="Eu153">
+            <atom value="152.921" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Eu">
+            <fraction n="0.4781" ref="Eu151"/>
+            <fraction n="0.5219" ref="Eu153"/>
+        </element>
+        <isotope Z="64.0" N="152" name="Gd152">
+            <atom value="151.92" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="154" name="Gd154">
+            <atom value="153.921" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="155" name="Gd155">
+            <atom value="154.923" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="156" name="Gd156">
+            <atom value="155.922" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="157" name="Gd157">
+            <atom value="156.924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="158" name="Gd158">
+            <atom value="157.924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="160" name="Gd160">
+            <atom value="159.927" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Gd">
+            <fraction n="0.002" ref="Gd152"/>
+            <fraction n="0.0218" ref="Gd154"/>
+            <fraction n="0.148" ref="Gd155"/>
+            <fraction n="0.2047" ref="Gd156"/>
+            <fraction n="0.1565" ref="Gd157"/>
+            <fraction n="0.2484" ref="Gd158"/>
+            <fraction n="0.2186" ref="Gd160"/>
+        </element>
+        <isotope Z="65.0" N="159" name="Tb159">
+            <atom value="158.925" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Tb">
+            <fraction n="1.0" ref="Tb159"/>
+        </element>
+        <isotope Z="66.0" N="156" name="Dy156">
+            <atom value="155.924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="158" name="Dy158">
+            <atom value="157.924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="160" name="Dy160">
+            <atom value="159.925" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="161" name="Dy161">
+            <atom value="160.927" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="162" name="Dy162">
+            <atom value="161.927" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="163" name="Dy163">
+            <atom value="162.929" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="164" name="Dy164">
+            <atom value="163.929" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Dy">
+            <fraction n="6.0E-4" ref="Dy156"/>
+            <fraction n="0.001" ref="Dy158"/>
+            <fraction n="0.0234" ref="Dy160"/>
+            <fraction n="0.1891" ref="Dy161"/>
+            <fraction n="0.2551" ref="Dy162"/>
+            <fraction n="0.249" ref="Dy163"/>
+            <fraction n="0.2818" ref="Dy164"/>
+        </element>
+        <isotope Z="67.0" N="165" name="Ho165">
+            <atom value="164.93" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ho">
+            <fraction n="1.0" ref="Ho165"/>
+        </element>
+        <isotope Z="68.0" N="162" name="Er162">
+            <atom value="161.929" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="164" name="Er164">
+            <atom value="163.929" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="166" name="Er166">
+            <atom value="165.93" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="167" name="Er167">
+            <atom value="166.932" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="168" name="Er168">
+            <atom value="167.932" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="170" name="Er170">
+            <atom value="169.935" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Er">
+            <fraction n="0.0014" ref="Er162"/>
+            <fraction n="0.0161" ref="Er164"/>
+            <fraction n="0.3361" ref="Er166"/>
+            <fraction n="0.2293" ref="Er167"/>
+            <fraction n="0.2678" ref="Er168"/>
+            <fraction n="0.1493" ref="Er170"/>
+        </element>
+        <isotope Z="69.0" N="169" name="Tm169">
+            <atom value="168.934" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Tm">
+            <fraction n="1.0" ref="Tm169"/>
+        </element>
+        <isotope Z="70.0" N="168" name="Yb168">
+            <atom value="167.934" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="170" name="Yb170">
+            <atom value="169.935" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="171" name="Yb171">
+            <atom value="170.936" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="172" name="Yb172">
+            <atom value="171.936" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="173" name="Yb173">
+            <atom value="172.938" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="174" name="Yb174">
+            <atom value="173.939" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="176" name="Yb176">
+            <atom value="175.943" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Yb">
+            <fraction n="0.0013" ref="Yb168"/>
+            <fraction n="0.0304" ref="Yb170"/>
+            <fraction n="0.1428" ref="Yb171"/>
+            <fraction n="0.2183" ref="Yb172"/>
+            <fraction n="0.1613" ref="Yb173"/>
+            <fraction n="0.3183" ref="Yb174"/>
+            <fraction n="0.1276" ref="Yb176"/>
+        </element>
+        <isotope Z="71.0" N="175" name="Lu175">
+            <atom value="174.941" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="71.0" N="176" name="Lu176">
+            <atom value="175.943" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Lu">
+            <fraction n="0.9741" ref="Lu175"/>
+            <fraction n="0.0259" ref="Lu176"/>
+        </element>
+        <isotope Z="72.0" N="174" name="Hf174">
+            <atom value="173.94" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="176" name="Hf176">
+            <atom value="175.941" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="177" name="Hf177">
+            <atom value="176.943" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="178" name="Hf178">
+            <atom value="177.944" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="179" name="Hf179">
+            <atom value="178.946" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="180" name="Hf180">
+            <atom value="179.947" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Hf">
+            <fraction n="0.0016" ref="Hf174"/>
+            <fraction n="0.0526" ref="Hf176"/>
+            <fraction n="0.186" ref="Hf177"/>
+            <fraction n="0.2728" ref="Hf178"/>
+            <fraction n="0.1362" ref="Hf179"/>
+            <fraction n="0.3508" ref="Hf180"/>
+        </element>
+        <isotope Z="73.0" N="180" name="Ta180">
+            <atom value="179.947" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="73.0" N="181" name="Ta181">
+            <atom value="180.948" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ta">
+            <fraction n="1.2E-4" ref="Ta180"/>
+            <fraction n="0.99988" ref="Ta181"/>
+        </element>
+        <isotope Z="74.0" N="180" name="W180">
+            <atom value="179.947" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="74.0" N="182" name="W182">
+            <atom value="181.948" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="74.0" N="183" name="W183">
+            <atom value="182.95" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="74.0" N="184" name="W184">
+            <atom value="183.951" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="74.0" N="186" name="W186">
+            <atom value="185.954" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="W">
+            <fraction n="0.0012" ref="W180"/>
+            <fraction n="0.265" ref="W182"/>
+            <fraction n="0.1431" ref="W183"/>
+            <fraction n="0.3064" ref="W184"/>
+            <fraction n="0.2843" ref="W186"/>
+        </element>
+        <isotope Z="75.0" N="185" name="Re185">
+            <atom value="184.953" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="75.0" N="187" name="Re187">
+            <atom value="186.956" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Re">
+            <fraction n="0.374" ref="Re185"/>
+            <fraction n="0.626" ref="Re187"/>
+        </element>
+        <isotope Z="76.0" N="184" name="Os184">
+            <atom value="183.952" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="186" name="Os186">
+            <atom value="185.954" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="187" name="Os187">
+            <atom value="186.956" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="188" name="Os188">
+            <atom value="187.956" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="189" name="Os189">
+            <atom value="188.958" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="190" name="Os190">
+            <atom value="189.958" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="192" name="Os192">
+            <atom value="191.961" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Os">
+            <fraction n="2.0E-4" ref="Os184"/>
+            <fraction n="0.0159" ref="Os186"/>
+            <fraction n="0.0196" ref="Os187"/>
+            <fraction n="0.1324" ref="Os188"/>
+            <fraction n="0.1615" ref="Os189"/>
+            <fraction n="0.2626" ref="Os190"/>
+            <fraction n="0.4078" ref="Os192"/>
+        </element>
+        <isotope Z="77.0" N="191" name="Ir191">
+            <atom value="190.961" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="77.0" N="193" name="Ir193">
+            <atom value="192.963" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ir">
+            <fraction n="0.373" ref="Ir191"/>
+            <fraction n="0.627" ref="Ir193"/>
+        </element>
+        <isotope Z="78.0" N="190" name="Pt190">
+            <atom value="189.96" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="192" name="Pt192">
+            <atom value="191.961" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="194" name="Pt194">
+            <atom value="193.963" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="195" name="Pt195">
+            <atom value="194.965" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="196" name="Pt196">
+            <atom value="195.965" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="198" name="Pt198">
+            <atom value="197.968" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pt">
+            <fraction n="1.4E-4" ref="Pt190"/>
+            <fraction n="0.00782" ref="Pt192"/>
+            <fraction n="0.32967" ref="Pt194"/>
+            <fraction n="0.33832" ref="Pt195"/>
+            <fraction n="0.25242" ref="Pt196"/>
+            <fraction n="0.07163" ref="Pt198"/>
+        </element>
+        <isotope Z="79.0" N="197" name="Au197">
+            <atom value="196.967" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Au">
+            <fraction n="1.0" ref="Au197"/>
+        </element>
+        <isotope Z="80.0" N="196" name="Hg196">
+            <atom value="195.966" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="198" name="Hg198">
+            <atom value="197.967" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="199" name="Hg199">
+            <atom value="198.968" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="200" name="Hg200">
+            <atom value="199.968" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="201" name="Hg201">
+            <atom value="200.97" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="202" name="Hg202">
+            <atom value="201.971" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="204" name="Hg204">
+            <atom value="203.973" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Hg">
+            <fraction n="0.0015" ref="Hg196"/>
+            <fraction n="0.0997" ref="Hg198"/>
+            <fraction n="0.1687" ref="Hg199"/>
+            <fraction n="0.231" ref="Hg200"/>
+            <fraction n="0.1318" ref="Hg201"/>
+            <fraction n="0.2986" ref="Hg202"/>
+            <fraction n="0.0687" ref="Hg204"/>
+        </element>
+        <isotope Z="81.0" N="203" name="Tl203">
+            <atom value="202.972" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="81.0" N="205" name="Tl205">
+            <atom value="204.974" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Tl">
+            <fraction n="0.29524" ref="Tl203"/>
+            <fraction n="0.70476" ref="Tl205"/>
+        </element>
+        <isotope Z="82.0" N="204" name="Pb204">
+            <atom value="203.973" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="206" name="Pb206">
+            <atom value="205.974" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="207" name="Pb207">
+            <atom value="206.976" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="208" name="Pb208">
+            <atom value="207.977" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pb">
+            <fraction n="0.014" ref="Pb204"/>
+            <fraction n="0.241" ref="Pb206"/>
+            <fraction n="0.221" ref="Pb207"/>
+            <fraction n="0.524" ref="Pb208"/>
+        </element>
+        <isotope Z="83.0" N="209" name="Bi209">
+            <atom value="208.98" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Bi">
+            <fraction n="1.0" ref="Bi209"/>
+        </element>
+        <isotope Z="84.0" N="209" name="Po209">
+            <atom value="208.982" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Po">
+            <fraction n="1.0" ref="Po209"/>
+        </element>
+        <isotope Z="85.0" N="210" name="At210">
+            <atom value="209.987" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="At">
+            <fraction n="1.0" ref="At210"/>
+        </element>
+        <isotope Z="86.0" N="222" name="Rn222">
+            <atom value="222.018" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Rn">
+            <fraction n="1.0" ref="Rn222"/>
+        </element>
+        <isotope Z="87.0" N="223" name="Fr223">
+            <atom value="223.02" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Fr">
+            <fraction n="1.0" ref="Fr223"/>
+        </element>
+        <isotope Z="88.0" N="226" name="Ra226">
+            <atom value="226.025" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ra">
+            <fraction n="1.0" ref="Ra226"/>
+        </element>
+        <isotope Z="89.0" N="227" name="Ac227">
+            <atom value="227.028" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ac">
+            <fraction n="1.0" ref="Ac227"/>
+        </element>
+        <isotope Z="90.0" N="232" name="Th232">
+            <atom value="232.038" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Th">
+            <fraction n="1.0" ref="Th232"/>
+        </element>
+        <isotope Z="91.0" N="231" name="Pa231">
+            <atom value="231.036" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pa">
+            <fraction n="1.0" ref="Pa231"/>
+        </element>
+        <isotope Z="92.0" N="234" name="U234">
+            <atom value="234.041" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="92.0" N="235" name="U235">
+            <atom value="235.044" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="92.0" N="238" name="U238">
+            <atom value="238.051" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="U">
+            <fraction n="5.5E-5" ref="U234"/>
+            <fraction n="0.0072" ref="U235"/>
+            <fraction n="0.992745" ref="U238"/>
+        </element>
+        <isotope Z="93.0" N="237" name="Np237">
+            <atom value="237.048" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Np">
+            <fraction n="1.0" ref="Np237"/>
+        </element>
+        <isotope Z="94.0" N="244" name="Pu244">
+            <atom value="244.064" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pu">
+            <fraction n="1.0" ref="Pu244"/>
+        </element>
+        <isotope Z="95.0" N="243" name="Am243">
+            <atom value="243.061" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Am">
+            <fraction n="1.0" ref="Am243"/>
+        </element>
+        <isotope Z="96.0" N="247" name="Cm247">
+            <atom value="247.07" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cm">
+            <fraction n="1.0" ref="Cm247"/>
+        </element>
+        <isotope Z="97.0" N="247" name="Bk247">
+            <atom value="247.07" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Bk">
+            <fraction n="1.0" ref="Bk247"/>
+        </element>
+        <isotope Z="98.0" N="251" name="Cf251">
+            <atom value="251.08" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cf">
+            <fraction n="1.0" ref="Cf251"/>
+        </element>
+        <material state="solid" name="G4_WATER">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.111898" ref="H"/>
+            <fraction n="0.888102" ref="O"/>
+        </material>
+        <material state="gas" name="G4_H">
+            <D value="8.3748E-5" unit="g/cm3"/>
+            <fraction n="1.0" ref="H"/>
+        </material>
+        <material state="gas" name="G4_He">
+            <D value="1.66322E-4" unit="g/cm3"/>
+            <fraction n="1.0" ref="He"/>
+        </material>
+        <material state="solid" name="G4_Li">
+            <D value="0.534" unit="g/cm3"/>
+            <fraction n="1.0" ref="Li"/>
+        </material>
+        <material state="solid" name="G4_Be">
+            <D value="1.848" unit="g/cm3"/>
+            <fraction n="1.0" ref="Be"/>
+        </material>
+        <material state="solid" name="G4_B">
+            <D value="2.37" unit="g/cm3"/>
+            <fraction n="1.0" ref="B"/>
+        </material>
+        <material state="solid" name="G4_C">
+            <D value="2.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="C"/>
+        </material>
+        <material state="gas" name="G4_N">
+            <D value="0.0011652" unit="g/cm3"/>
+            <fraction n="1.0" ref="N"/>
+        </material>
+        <material state="gas" name="G4_O">
+            <D value="0.00133151" unit="g/cm3"/>
+            <fraction n="1.0" ref="O"/>
+        </material>
+        <material state="gas" name="G4_F">
+            <D value="0.00158029" unit="g/cm3"/>
+            <fraction n="1.0" ref="F"/>
+        </material>
+        <material state="gas" name="G4_Ne">
+            <D value="8.38505E-4" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ne"/>
+        </material>
+        <material state="solid" name="G4_Na">
+            <D value="0.971" unit="g/cm3"/>
+            <fraction n="1.0" ref="Na"/>
+        </material>
+        <material state="solid" name="G4_Mg">
+            <D value="1.74" unit="g/cm3"/>
+            <fraction n="1.0" ref="Mg"/>
+        </material>
+        <material state="solid" name="G4_Al">
+            <D value="2.699" unit="g/cm3"/>
+            <fraction n="1.0" ref="Al"/>
+        </material>
+        <material state="solid" name="G4_Si">
+            <D value="2.33" unit="g/cm3"/>
+            <fraction n="1.0" ref="Si"/>
+        </material>
+        <material state="solid" name="G4_P">
+            <D value="2.2" unit="g/cm3"/>
+            <fraction n="1.0" ref="P"/>
+        </material>
+        <material state="solid" name="G4_S">
+            <D value="2.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="S"/>
+        </material>
+        <material state="gas" name="G4_Cl">
+            <D value="0.00299473" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cl"/>
+        </material>
+        <material state="gas" name="G4_Ar">
+            <D value="0.00166201" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ar"/>
+        </material>
+        <material state="solid" name="G4_K">
+            <D value="0.862" unit="g/cm3"/>
+            <fraction n="1.0" ref="K"/>
+        </material>
+        <material state="solid" name="G4_Ca">
+            <D value="1.55" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_Sc">
+            <D value="2.989" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sc"/>
+        </material>
+        <material state="solid" name="G4_Ti">
+            <D value="4.54" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ti"/>
+        </material>
+        <material state="solid" name="G4_V">
+            <D value="6.11" unit="g/cm3"/>
+            <fraction n="1.0" ref="V"/>
+        </material>
+        <material state="solid" name="G4_Cr">
+            <D value="7.18" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cr"/>
+        </material>
+        <material state="solid" name="G4_Mn">
+            <D value="7.44" unit="g/cm3"/>
+            <fraction n="1.0" ref="Mn"/>
+        </material>
+        <material state="solid" name="G4_Fe">
+            <D value="7.874" unit="g/cm3"/>
+            <fraction n="1.0" ref="Fe"/>
+        </material>
+        <material state="solid" name="G4_Co">
+            <D value="8.9" unit="g/cm3"/>
+            <fraction n="1.0" ref="Co"/>
+        </material>
+        <material state="solid" name="G4_Ni">
+            <D value="8.902" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ni"/>
+        </material>
+        <material state="solid" name="G4_Cu">
+            <D value="8.96" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cu"/>
+        </material>
+        <material state="solid" name="G4_Zn">
+            <D value="7.133" unit="g/cm3"/>
+            <fraction n="1.0" ref="Zn"/>
+        </material>
+        <material state="solid" name="G4_Ga">
+            <D value="5.904" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ga"/>
+        </material>
+        <material state="solid" name="G4_Ge">
+            <D value="5.323" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ge"/>
+        </material>
+        <material state="solid" name="G4_As">
+            <D value="5.73" unit="g/cm3"/>
+            <fraction n="1.0" ref="As"/>
+        </material>
+        <material state="solid" name="G4_Se">
+            <D value="4.5" unit="g/cm3"/>
+            <fraction n="1.0" ref="Se"/>
+        </material>
+        <material state="gas" name="G4_Br">
+            <D value="0.0070721" unit="g/cm3"/>
+            <fraction n="1.0" ref="Br"/>
+        </material>
+        <material state="gas" name="G4_Kr">
+            <D value="0.00347832" unit="g/cm3"/>
+            <fraction n="1.0" ref="Kr"/>
+        </material>
+        <material state="solid" name="G4_Rb">
+            <D value="1.532" unit="g/cm3"/>
+            <fraction n="1.0" ref="Rb"/>
+        </material>
+        <material state="solid" name="G4_Sr">
+            <D value="2.54" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sr"/>
+        </material>
+        <material state="solid" name="G4_Y">
+            <D value="4.469" unit="g/cm3"/>
+            <fraction n="1.0" ref="Y"/>
+        </material>
+        <material state="solid" name="G4_Zr">
+            <D value="6.506" unit="g/cm3"/>
+            <fraction n="1.0" ref="Zr"/>
+        </material>
+        <material state="solid" name="G4_Nb">
+            <D value="8.57" unit="g/cm3"/>
+            <fraction n="1.0" ref="Nb"/>
+        </material>
+        <material state="solid" name="G4_Mo">
+            <D value="10.22" unit="g/cm3"/>
+            <fraction n="1.0" ref="Mo"/>
+        </material>
+        <material state="solid" name="G4_Tc">
+            <D value="11.5" unit="g/cm3"/>
+            <fraction n="1.0" ref="Tc"/>
+        </material>
+        <material state="solid" name="G4_Ru">
+            <D value="12.41" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ru"/>
+        </material>
+        <material state="solid" name="G4_Rh">
+            <D value="12.41" unit="g/cm3"/>
+            <fraction n="1.0" ref="Rh"/>
+        </material>
+        <material state="solid" name="G4_Pd">
+            <D value="12.02" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pd"/>
+        </material>
+        <material state="solid" name="G4_Ag">
+            <D value="10.5" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ag"/>
+        </material>
+        <material state="solid" name="G4_Cd">
+            <D value="8.65" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cd"/>
+        </material>
+        <material state="solid" name="G4_In">
+            <D value="7.31" unit="g/cm3"/>
+            <fraction n="1.0" ref="In"/>
+        </material>
+        <material state="solid" name="G4_Sn">
+            <D value="7.31" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sn"/>
+        </material>
+        <material state="solid" name="G4_Sb">
+            <D value="6.691" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sb"/>
+        </material>
+        <material state="solid" name="G4_Te">
+            <D value="6.24" unit="g/cm3"/>
+            <fraction n="1.0" ref="Te"/>
+        </material>
+        <material state="solid" name="G4_I">
+            <D value="4.93" unit="g/cm3"/>
+            <fraction n="1.0" ref="I"/>
+        </material>
+        <material state="gas" name="G4_Xe">
+            <D value="0.00548536" unit="g/cm3"/>
+            <fraction n="1.0" ref="Xe"/>
+        </material>
+        <material state="solid" name="G4_Cs">
+            <D value="1.873" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cs"/>
+        </material>
+        <material state="solid" name="G4_Ba">
+            <D value="3.5" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ba"/>
+        </material>
+        <material state="solid" name="G4_La">
+            <D value="6.154" unit="g/cm3"/>
+            <fraction n="1.0" ref="La"/>
+        </material>
+        <material state="solid" name="G4_Ce">
+            <D value="6.657" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ce"/>
+        </material>
+        <material state="solid" name="G4_Pr">
+            <D value="6.71" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pr"/>
+        </material>
+        <material state="solid" name="G4_Nd">
+            <D value="6.9" unit="g/cm3"/>
+            <fraction n="1.0" ref="Nd"/>
+        </material>
+        <material state="solid" name="G4_Pm">
+            <D value="7.22" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pm"/>
+        </material>
+        <material state="solid" name="G4_Sm">
+            <D value="7.46" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sm"/>
+        </material>
+        <material state="solid" name="G4_Eu">
+            <D value="5.243" unit="g/cm3"/>
+            <fraction n="1.0" ref="Eu"/>
+        </material>
+        <material state="solid" name="G4_Gd">
+            <D value="7.9004" unit="g/cm3"/>
+            <fraction n="1.0" ref="Gd"/>
+        </material>
+        <material state="solid" name="G4_Tb">
+            <D value="8.229" unit="g/cm3"/>
+            <fraction n="1.0" ref="Tb"/>
+        </material>
+        <material state="solid" name="G4_Dy">
+            <D value="8.55" unit="g/cm3"/>
+            <fraction n="1.0" ref="Dy"/>
+        </material>
+        <material state="solid" name="G4_Ho">
+            <D value="8.795" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ho"/>
+        </material>
+        <material state="solid" name="G4_Er">
+            <D value="9.066" unit="g/cm3"/>
+            <fraction n="1.0" ref="Er"/>
+        </material>
+        <material state="solid" name="G4_Tm">
+            <D value="9.321" unit="g/cm3"/>
+            <fraction n="1.0" ref="Tm"/>
+        </material>
+        <material state="solid" name="G4_Yb">
+            <D value="6.73" unit="g/cm3"/>
+            <fraction n="1.0" ref="Yb"/>
+        </material>
+        <material state="solid" name="G4_Lu">
+            <D value="9.84" unit="g/cm3"/>
+            <fraction n="1.0" ref="Lu"/>
+        </material>
+        <material state="solid" name="G4_Hf">
+            <D value="13.31" unit="g/cm3"/>
+            <fraction n="1.0" ref="Hf"/>
+        </material>
+        <material state="solid" name="G4_Ta">
+            <D value="16.654" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ta"/>
+        </material>
+        <material state="solid" name="G4_W">
+            <D value="19.3" unit="g/cm3"/>
+            <fraction n="1.0" ref="W"/>
+        </material>
+        <material state="solid" name="G4_Re">
+            <D value="21.02" unit="g/cm3"/>
+            <fraction n="1.0" ref="Re"/>
+        </material>
+        <material state="solid" name="G4_Os">
+            <D value="22.57" unit="g/cm3"/>
+            <fraction n="1.0" ref="Os"/>
+        </material>
+        <material state="solid" name="G4_Ir">
+            <D value="22.42" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ir"/>
+        </material>
+        <material state="solid" name="G4_Pt">
+            <D value="21.45" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pt"/>
+        </material>
+        <material state="solid" name="G4_Au">
+            <D value="19.32" unit="g/cm3"/>
+            <fraction n="1.0" ref="Au"/>
+        </material>
+        <material state="solid" name="G4_Hg">
+            <D value="13.546" unit="g/cm3"/>
+            <fraction n="1.0" ref="Hg"/>
+        </material>
+        <material state="solid" name="G4_Tl">
+            <D value="11.72" unit="g/cm3"/>
+            <fraction n="1.0" ref="Tl"/>
+        </material>
+        <material state="solid" name="G4_Pb">
+            <D value="11.35" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_Bi">
+            <D value="9.747" unit="g/cm3"/>
+            <fraction n="1.0" ref="Bi"/>
+        </material>
+        <material state="solid" name="G4_Po">
+            <D value="9.32" unit="g/cm3"/>
+            <fraction n="1.0" ref="Po"/>
+        </material>
+        <material state="solid" name="G4_At">
+            <D value="9.32" unit="g/cm3"/>
+            <fraction n="1.0" ref="At"/>
+        </material>
+        <material state="gas" name="G4_Rn">
+            <D value="0.00900662" unit="g/cm3"/>
+            <fraction n="1.0" ref="Rn"/>
+        </material>
+        <material state="solid" name="G4_Fr">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="Fr"/>
+        </material>
+        <material state="solid" name="G4_Ra">
+            <D value="5.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ra"/>
+        </material>
+        <material state="solid" name="G4_Ac">
+            <D value="10.07" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ac"/>
+        </material>
+        <material state="solid" name="G4_Th">
+            <D value="11.72" unit="g/cm3"/>
+            <fraction n="1.0" ref="Th"/>
+        </material>
+        <material state="solid" name="G4_Pa">
+            <D value="15.37" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pa"/>
+        </material>
+        <material state="solid" name="G4_U">
+            <D value="18.95" unit="g/cm3"/>
+            <fraction n="1.0" ref="U"/>
+        </material>
+        <material state="solid" name="G4_Np">
+            <D value="20.25" unit="g/cm3"/>
+            <fraction n="1.0" ref="Np"/>
+        </material>
+        <material state="solid" name="G4_Pu">
+            <D value="19.84" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pu"/>
+        </material>
+        <material state="solid" name="G4_Am">
+            <D value="13.67" unit="g/cm3"/>
+            <fraction n="1.0" ref="Am"/>
+        </material>
+        <material state="solid" name="G4_Cm">
+            <D value="13.51" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cm"/>
+        </material>
+        <material state="solid" name="G4_Bk">
+            <D value="14.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="Bk"/>
+        </material>
+        <material state="solid" name="G4_Cf">
+            <D value="10.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cf"/>
+        </material>
+        <material state="solid" name="G4_A-150_TISSUE">
+            <D value="1.127" unit="g/cm3"/>
+            <fraction n="0.101327" ref="H"/>
+            <fraction n="0.7755" ref="C"/>
+            <fraction n="0.035057" ref="N"/>
+            <fraction n="0.052316" ref="O"/>
+            <fraction n="0.017422" ref="F"/>
+            <fraction n="0.018378" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_ACETONE">
+            <D value="0.7899" unit="g/cm3"/>
+            <fraction n="0.620397" ref="C"/>
+            <fraction n="0.104127" ref="H"/>
+            <fraction n="0.275475" ref="O"/>
+        </material>
+        <material state="gas" name="G4_ACETYLENE">
+            <D value="0.0010967" unit="g/cm3"/>
+            <fraction n="0.922577" ref="C"/>
+            <fraction n="0.077423" ref="H"/>
+        </material>
+        <material state="solid" name="G4_ADENINE">
+            <D value="1.6" unit="g/cm3"/>
+            <fraction n="0.444423" ref="C"/>
+            <fraction n="0.037296" ref="H"/>
+            <fraction n="0.518281" ref="N"/>
+        </material>
+        <material state="solid" name="G4_ADIPOSE_TISSUE_ICRP">
+            <D value="0.95" unit="g/cm3"/>
+            <fraction n="0.114" ref="H"/>
+            <fraction n="0.598" ref="C"/>
+            <fraction n="0.007" ref="N"/>
+            <fraction n="0.278" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="S"/>
+            <fraction n="0.001" ref="Cl"/>
+        </material>
+        <material state="gas" name="G4_AIR">
+            <D value="0.00120479" unit="g/cm3"/>
+            <fraction n="1.24E-4" ref="C"/>
+            <fraction n="0.755268" ref="N"/>
+            <fraction n="0.231781" ref="O"/>
+            <fraction n="0.012827" ref="Ar"/>
+        </material>
+        <material state="solid" name="G4_ALANINE">
+            <D value="1.42" unit="g/cm3"/>
+            <fraction n="0.404432" ref="C"/>
+            <fraction n="0.079193" ref="H"/>
+            <fraction n="0.157215" ref="N"/>
+            <fraction n="0.35916" ref="O"/>
+        </material>
+        <material state="solid" name="G4_ALUMINUM_OXIDE">
+            <D value="3.97" unit="g/cm3"/>
+            <fraction n="0.52925" ref="Al"/>
+            <fraction n="0.47075" ref="O"/>
+        </material>
+        <material state="solid" name="G4_AMBER">
+            <D value="1.1" unit="g/cm3"/>
+            <fraction n="0.10593" ref="H"/>
+            <fraction n="0.788974" ref="C"/>
+            <fraction n="0.105096" ref="O"/>
+        </material>
+        <material state="gas" name="G4_AMMONIA">
+            <D value="8.26019E-4" unit="g/cm3"/>
+            <fraction n="0.822448" ref="N"/>
+            <fraction n="0.177552" ref="H"/>
+        </material>
+        <material state="solid" name="G4_ANILINE">
+            <D value="1.0235" unit="g/cm3"/>
+            <fraction n="0.773831" ref="C"/>
+            <fraction n="0.075763" ref="H"/>
+            <fraction n="0.150405" ref="N"/>
+        </material>
+        <material state="solid" name="G4_ANTHRACENE">
+            <D value="1.283" unit="g/cm3"/>
+            <fraction n="0.943447" ref="C"/>
+            <fraction n="0.056553" ref="H"/>
+        </material>
+        <material state="solid" name="G4_B-100_BONE">
+            <D value="1.45" unit="g/cm3"/>
+            <fraction n="0.065471" ref="H"/>
+            <fraction n="0.536944" ref="C"/>
+            <fraction n="0.0215" ref="N"/>
+            <fraction n="0.032085" ref="O"/>
+            <fraction n="0.167411" ref="F"/>
+            <fraction n="0.176589" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_BAKELITE">
+            <D value="1.25" unit="g/cm3"/>
+            <fraction n="0.057441" ref="H"/>
+            <fraction n="0.774591" ref="C"/>
+            <fraction n="0.167968" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BARIUM_FLUORIDE">
+            <D value="4.89" unit="g/cm3"/>
+            <fraction n="0.783276" ref="Ba"/>
+            <fraction n="0.216724" ref="F"/>
+        </material>
+        <material state="solid" name="G4_BARIUM_SULFATE">
+            <D value="4.5" unit="g/cm3"/>
+            <fraction n="0.588399" ref="Ba"/>
+            <fraction n="0.137393" ref="S"/>
+            <fraction n="0.274208" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BENZENE">
+            <D value="0.87865" unit="g/cm3"/>
+            <fraction n="0.922577" ref="C"/>
+            <fraction n="0.077423" ref="H"/>
+        </material>
+        <material state="solid" name="G4_BERYLLIUM_OXIDE">
+            <D value="3.01" unit="g/cm3"/>
+            <fraction n="0.36032" ref="Be"/>
+            <fraction n="0.63968" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BGO">
+            <D value="7.13" unit="g/cm3"/>
+            <fraction n="0.671017" ref="Bi"/>
+            <fraction n="0.174865" ref="Ge"/>
+            <fraction n="0.154118" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BLOOD_ICRP">
+            <D value="1.06" unit="g/cm3"/>
+            <fraction n="0.102" ref="H"/>
+            <fraction n="0.11" ref="C"/>
+            <fraction n="0.033" ref="N"/>
+            <fraction n="0.745" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+            <fraction n="0.001" ref="Fe"/>
+        </material>
+        <material state="solid" name="G4_BONE_COMPACT_ICRU">
+            <D value="1.85" unit="g/cm3"/>
+            <fraction n="0.064" ref="H"/>
+            <fraction n="0.278" ref="C"/>
+            <fraction n="0.027" ref="N"/>
+            <fraction n="0.41" ref="O"/>
+            <fraction n="0.002" ref="Mg"/>
+            <fraction n="0.07" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.147" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_BONE_CORTICAL_ICRP">
+            <D value="1.92" unit="g/cm3"/>
+            <fraction n="0.034" ref="H"/>
+            <fraction n="0.155" ref="C"/>
+            <fraction n="0.042" ref="N"/>
+            <fraction n="0.435" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.002" ref="Mg"/>
+            <fraction n="0.103" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.225" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_BORON_CARBIDE">
+            <D value="2.52" unit="g/cm3"/>
+            <fraction n="0.78263" ref="B"/>
+            <fraction n="0.21737" ref="C"/>
+        </material>
+        <material state="solid" name="G4_BORON_OXIDE">
+            <D value="1.812" unit="g/cm3"/>
+            <fraction n="0.310571" ref="B"/>
+            <fraction n="0.689429" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BRAIN_ICRP">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.107" ref="H"/>
+            <fraction n="0.145" ref="C"/>
+            <fraction n="0.022" ref="N"/>
+            <fraction n="0.712" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.004" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.003" ref="K"/>
+        </material>
+        <material state="solid" name="G4_BREAST_ICRP">
+            <D value="1.02" unit="g/cm3"/>
+            <fraction n="0.106" ref="H"/>
+            <fraction n="0.332" ref="C"/>
+            <fraction n="0.03" ref="N"/>
+            <fraction n="0.527" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.001" ref="Cl"/>
+        </material>
+        <material state="gas" name="G4_BUTANE">
+            <D value="0.00249343" unit="g/cm3"/>
+            <fraction n="0.826583" ref="C"/>
+            <fraction n="0.173417" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-BUTYL_ALCOHOL">
+            <D value="0.8098" unit="g/cm3"/>
+            <fraction n="0.648163" ref="C"/>
+            <fraction n="0.135984" ref="H"/>
+            <fraction n="0.215853" ref="O"/>
+        </material>
+        <material state="solid" name="G4_C-552">
+            <D value="1.76" unit="g/cm3"/>
+            <fraction n="0.02468" ref="H"/>
+            <fraction n="0.501611" ref="C"/>
+            <fraction n="0.004527" ref="O"/>
+            <fraction n="0.465209" ref="F"/>
+            <fraction n="0.003973" ref="Si"/>
+        </material>
+        <material state="solid" name="G4_CADMIUM_TELLURIDE">
+            <D value="6.2" unit="g/cm3"/>
+            <fraction n="0.468353" ref="Cd"/>
+            <fraction n="0.531647" ref="Te"/>
+        </material>
+        <material state="solid" name="G4_CADMIUM_TUNGSTATE">
+            <D value="7.9" unit="g/cm3"/>
+            <fraction n="0.312037" ref="Cd"/>
+            <fraction n="0.510316" ref="W"/>
+            <fraction n="0.177647" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_CARBONATE">
+            <D value="2.8" unit="g/cm3"/>
+            <fraction n="0.400432" ref="Ca"/>
+            <fraction n="0.120003" ref="C"/>
+            <fraction n="0.479565" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_FLUORIDE">
+            <D value="3.18" unit="g/cm3"/>
+            <fraction n="0.513328" ref="Ca"/>
+            <fraction n="0.486672" ref="F"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_OXIDE">
+            <D value="3.3" unit="g/cm3"/>
+            <fraction n="0.714691" ref="Ca"/>
+            <fraction n="0.285309" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_SULFATE">
+            <D value="2.96" unit="g/cm3"/>
+            <fraction n="0.294385" ref="Ca"/>
+            <fraction n="0.235535" ref="S"/>
+            <fraction n="0.47008" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_TUNGSTATE">
+            <D value="6.062" unit="g/cm3"/>
+            <fraction n="0.1392" ref="Ca"/>
+            <fraction n="0.638522" ref="W"/>
+            <fraction n="0.222278" ref="O"/>
+        </material>
+        <material state="gas" name="G4_CARBON_DIOXIDE">
+            <D value="0.00184212" unit="g/cm3"/>
+            <fraction n="0.272912" ref="C"/>
+            <fraction n="0.727088" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CARBON_TETRACHLORIDE">
+            <D value="1.594" unit="g/cm3"/>
+            <fraction n="0.078083" ref="C"/>
+            <fraction n="0.921917" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_CELLULOSE_CELLOPHANE">
+            <D value="1.42" unit="g/cm3"/>
+            <fraction n="0.444456" ref="C"/>
+            <fraction n="0.062165" ref="H"/>
+            <fraction n="0.49338" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CELLULOSE_BUTYRATE">
+            <D value="1.2" unit="g/cm3"/>
+            <fraction n="0.067125" ref="H"/>
+            <fraction n="0.545403" ref="C"/>
+            <fraction n="0.387472" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CELLULOSE_NITRATE">
+            <D value="1.49" unit="g/cm3"/>
+            <fraction n="0.029216" ref="H"/>
+            <fraction n="0.271296" ref="C"/>
+            <fraction n="0.121276" ref="N"/>
+            <fraction n="0.578212" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CERIC_SULFATE">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.107596" ref="H"/>
+            <fraction n="8.0E-4" ref="N"/>
+            <fraction n="0.874976" ref="O"/>
+            <fraction n="0.014627" ref="S"/>
+            <fraction n="0.002001" ref="Ce"/>
+        </material>
+        <material state="solid" name="G4_CESIUM_FLUORIDE">
+            <D value="4.115" unit="g/cm3"/>
+            <fraction n="0.874931" ref="Cs"/>
+            <fraction n="0.125069" ref="F"/>
+        </material>
+        <material state="solid" name="G4_CESIUM_IODIDE">
+            <D value="4.51" unit="g/cm3"/>
+            <fraction n="0.511549" ref="Cs"/>
+            <fraction n="0.488451" ref="I"/>
+        </material>
+        <material state="solid" name="G4_CHLOROBENZENE">
+            <D value="1.1058" unit="g/cm3"/>
+            <fraction n="0.64025" ref="C"/>
+            <fraction n="0.044775" ref="H"/>
+            <fraction n="0.314975" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_CHLOROFORM">
+            <D value="1.4832" unit="g/cm3"/>
+            <fraction n="0.100612" ref="C"/>
+            <fraction n="0.008443" ref="H"/>
+            <fraction n="0.890944" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_CONCRETE">
+            <D value="2.3" unit="g/cm3"/>
+            <fraction n="0.01" ref="H"/>
+            <fraction n="0.001" ref="C"/>
+            <fraction n="0.529107" ref="O"/>
+            <fraction n="0.016" ref="Na"/>
+            <fraction n="0.002" ref="Mg"/>
+            <fraction n="0.033872" ref="Al"/>
+            <fraction n="0.337021" ref="Si"/>
+            <fraction n="0.013" ref="K"/>
+            <fraction n="0.044" ref="Ca"/>
+            <fraction n="0.014" ref="Fe"/>
+        </material>
+        <material state="solid" name="G4_CYCLOHEXANE">
+            <D value="0.779" unit="g/cm3"/>
+            <fraction n="0.856282" ref="C"/>
+            <fraction n="0.143718" ref="H"/>
+        </material>
+        <material state="solid" name="G4_1,2-DICHLOROBENZENE">
+            <D value="1.3048" unit="g/cm3"/>
+            <fraction n="0.49023" ref="C"/>
+            <fraction n="0.027427" ref="H"/>
+            <fraction n="0.482344" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_DICHLORODIETHYL_ETHER">
+            <D value="1.2199" unit="g/cm3"/>
+            <fraction n="0.335939" ref="C"/>
+            <fraction n="0.056384" ref="H"/>
+            <fraction n="0.111875" ref="O"/>
+            <fraction n="0.495802" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_1,2-DICHLOROETHANE">
+            <D value="1.2351" unit="g/cm3"/>
+            <fraction n="0.242743" ref="C"/>
+            <fraction n="0.040742" ref="H"/>
+            <fraction n="0.716515" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_DIETHYL_ETHER">
+            <D value="0.71378" unit="g/cm3"/>
+            <fraction n="0.648163" ref="C"/>
+            <fraction n="0.135984" ref="H"/>
+            <fraction n="0.215853" ref="O"/>
+        </material>
+        <material state="solid" name="G4_N,N-DIMETHYL_FORMAMIDE">
+            <D value="0.9487" unit="g/cm3"/>
+            <fraction n="0.492957" ref="C"/>
+            <fraction n="0.096528" ref="H"/>
+            <fraction n="0.191627" ref="N"/>
+            <fraction n="0.218888" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DIMETHYL_SULFOXIDE">
+            <D value="1.1014" unit="g/cm3"/>
+            <fraction n="0.307437" ref="C"/>
+            <fraction n="0.0774" ref="H"/>
+            <fraction n="0.204767" ref="O"/>
+            <fraction n="0.410396" ref="S"/>
+        </material>
+        <material state="gas" name="G4_ETHANE">
+            <D value="0.00125324" unit="g/cm3"/>
+            <fraction n="0.798875" ref="C"/>
+            <fraction n="0.201125" ref="H"/>
+        </material>
+        <material state="solid" name="G4_ETHYL_ALCOHOL">
+            <D value="0.7893" unit="g/cm3"/>
+            <fraction n="0.521429" ref="C"/>
+            <fraction n="0.131275" ref="H"/>
+            <fraction n="0.347296" ref="O"/>
+        </material>
+        <material state="solid" name="G4_ETHYL_CELLULOSE">
+            <D value="1.13" unit="g/cm3"/>
+            <fraction n="0.090027" ref="H"/>
+            <fraction n="0.585182" ref="C"/>
+            <fraction n="0.324791" ref="O"/>
+        </material>
+        <material state="gas" name="G4_ETHYLENE">
+            <D value="0.00117497" unit="g/cm3"/>
+            <fraction n="0.856282" ref="C"/>
+            <fraction n="0.143718" ref="H"/>
+        </material>
+        <material state="solid" name="G4_EYE_LENS_ICRP">
+            <D value="1.07" unit="g/cm3"/>
+            <fraction n="0.096" ref="H"/>
+            <fraction n="0.195" ref="C"/>
+            <fraction n="0.057" ref="N"/>
+            <fraction n="0.646" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.001" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_FERRIC_OXIDE">
+            <D value="5.2" unit="g/cm3"/>
+            <fraction n="0.699426" ref="Fe"/>
+            <fraction n="0.300574" ref="O"/>
+        </material>
+        <material state="solid" name="G4_FERROBORIDE">
+            <D value="7.15" unit="g/cm3"/>
+            <fraction n="0.837809" ref="Fe"/>
+            <fraction n="0.162191" ref="B"/>
+        </material>
+        <material state="solid" name="G4_FERROUS_OXIDE">
+            <D value="5.7" unit="g/cm3"/>
+            <fraction n="0.777305" ref="Fe"/>
+            <fraction n="0.222695" ref="O"/>
+        </material>
+        <material state="solid" name="G4_FERROUS_SULFATE">
+            <D value="1.024" unit="g/cm3"/>
+            <fraction n="0.108259" ref="H"/>
+            <fraction n="2.7E-5" ref="N"/>
+            <fraction n="0.878636" ref="O"/>
+            <fraction n="2.2E-5" ref="Na"/>
+            <fraction n="0.012968" ref="S"/>
+            <fraction n="3.4E-5" ref="Cl"/>
+            <fraction n="5.4E-5" ref="Fe"/>
+        </material>
+        <material state="solid" name="G4_FREON-12">
+            <D value="1.12" unit="g/cm3"/>
+            <fraction n="0.099335" ref="C"/>
+            <fraction n="0.314247" ref="F"/>
+            <fraction n="0.586418" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_FREON-12B2">
+            <D value="1.8" unit="g/cm3"/>
+            <fraction n="0.057245" ref="C"/>
+            <fraction n="0.181096" ref="F"/>
+            <fraction n="0.761659" ref="Br"/>
+        </material>
+        <material state="solid" name="G4_FREON-13">
+            <D value="0.95" unit="g/cm3"/>
+            <fraction n="0.114983" ref="C"/>
+            <fraction n="0.545621" ref="F"/>
+            <fraction n="0.339396" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_FREON-13B1">
+            <D value="1.5" unit="g/cm3"/>
+            <fraction n="0.080658" ref="C"/>
+            <fraction n="0.382751" ref="F"/>
+            <fraction n="0.536591" ref="Br"/>
+        </material>
+        <material state="solid" name="G4_FREON-13I1">
+            <D value="1.8" unit="g/cm3"/>
+            <fraction n="0.061309" ref="C"/>
+            <fraction n="0.290924" ref="F"/>
+            <fraction n="0.647767" ref="I"/>
+        </material>
+        <material state="solid" name="G4_GADOLINIUM_OXYSULFIDE">
+            <D value="7.44" unit="g/cm3"/>
+            <fraction n="0.830771" ref="Gd"/>
+            <fraction n="0.084526" ref="O"/>
+            <fraction n="0.084703" ref="S"/>
+        </material>
+        <material state="solid" name="G4_GALLIUM_ARSENIDE">
+            <D value="5.31" unit="g/cm3"/>
+            <fraction n="0.48203" ref="Ga"/>
+            <fraction n="0.51797" ref="As"/>
+        </material>
+        <material state="solid" name="G4_GEL_PHOTO_EMULSION">
+            <D value="1.2914" unit="g/cm3"/>
+            <fraction n="0.08118" ref="H"/>
+            <fraction n="0.41606" ref="C"/>
+            <fraction n="0.11124" ref="N"/>
+            <fraction n="0.38064" ref="O"/>
+            <fraction n="0.01088" ref="S"/>
+        </material>
+        <material state="solid" name="G4_Pyrex_Glass">
+            <D value="2.23" unit="g/cm3"/>
+            <fraction n="0.040064" ref="B"/>
+            <fraction n="0.539561" ref="O"/>
+            <fraction n="0.028191" ref="Na"/>
+            <fraction n="0.011644" ref="Al"/>
+            <fraction n="0.377219" ref="Si"/>
+            <fraction n="0.003321" ref="K"/>
+        </material>
+        <material state="solid" name="G4_GLASS_LEAD">
+            <D value="6.22" unit="g/cm3"/>
+            <fraction n="0.156453" ref="O"/>
+            <fraction n="0.080866" ref="Si"/>
+            <fraction n="0.008092" ref="Ti"/>
+            <fraction n="0.002651" ref="As"/>
+            <fraction n="0.751938" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_GLASS_PLATE">
+            <D value="2.4" unit="g/cm3"/>
+            <fraction n="0.4598" ref="O"/>
+            <fraction n="0.096441" ref="Na"/>
+            <fraction n="0.336553" ref="Si"/>
+            <fraction n="0.107205" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_GLUTAMINE">
+            <D value="1.46" unit="g/cm3"/>
+            <fraction n="0.410919" ref="C"/>
+            <fraction n="0.068969" ref="H"/>
+            <fraction n="0.191683" ref="N"/>
+            <fraction n="0.328429" ref="O"/>
+        </material>
+        <material state="solid" name="G4_GLYCEROL">
+            <D value="1.2613" unit="g/cm3"/>
+            <fraction n="0.391255" ref="C"/>
+            <fraction n="0.087558" ref="H"/>
+            <fraction n="0.521187" ref="O"/>
+        </material>
+        <material state="solid" name="G4_GUANINE">
+            <D value="2.2" unit="g/cm3"/>
+            <fraction n="0.397373" ref="C"/>
+            <fraction n="0.033348" ref="H"/>
+            <fraction n="0.463412" ref="N"/>
+            <fraction n="0.105867" ref="O"/>
+        </material>
+        <material state="solid" name="G4_GYPSUM">
+            <D value="2.32" unit="g/cm3"/>
+            <fraction n="0.232779" ref="Ca"/>
+            <fraction n="0.186244" ref="S"/>
+            <fraction n="0.55756" ref="O"/>
+            <fraction n="0.023417" ref="H"/>
+        </material>
+        <material state="solid" name="G4_HEART_ICRP">
+            <D value="1.055" unit="g/cm3"/>
+            <fraction n="0.103" ref="H"/>
+            <fraction n="0.121" ref="C"/>
+            <fraction n="0.032" ref="N"/>
+            <fraction n="0.734" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+        </material>
+        <material state="solid" name="G4_N-HEPTANE">
+            <D value="0.68376" unit="g/cm3"/>
+            <fraction n="0.839055" ref="C"/>
+            <fraction n="0.160945" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-HEXANE">
+            <D value="0.6603" unit="g/cm3"/>
+            <fraction n="0.836251" ref="C"/>
+            <fraction n="0.163749" ref="H"/>
+        </material>
+        <material state="solid" name="G4_KAPTON">
+            <D value="1.42" unit="g/cm3"/>
+            <fraction n="0.691128" ref="C"/>
+            <fraction n="0.026363" ref="H"/>
+            <fraction n="0.073271" ref="N"/>
+            <fraction n="0.209237" ref="O"/>
+        </material>
+        <material state="solid" name="G4_KIDNEY_ICRP">
+            <D value="1.05" unit="g/cm3"/>
+            <fraction n="0.103" ref="H"/>
+            <fraction n="0.132" ref="C"/>
+            <fraction n="0.03" ref="N"/>
+            <fraction n="0.724" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.002" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.002" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+            <fraction n="0.001" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_LANTHANUM_OXYBROMIDE">
+            <D value="6.28" unit="g/cm3"/>
+            <fraction n="0.591569" ref="La"/>
+            <fraction n="0.340293" ref="Br"/>
+            <fraction n="0.068138" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LANTHANUM_OXYSULFIDE">
+            <D value="5.86" unit="g/cm3"/>
+            <fraction n="0.812607" ref="La"/>
+            <fraction n="0.093598" ref="O"/>
+            <fraction n="0.093795" ref="S"/>
+        </material>
+        <material state="solid" name="G4_LEAD_OXIDE">
+            <D value="9.53" unit="g/cm3"/>
+            <fraction n="0.071682" ref="O"/>
+            <fraction n="0.928318" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_AMIDE">
+            <D value="1.178" unit="g/cm3"/>
+            <fraction n="0.302231" ref="Li"/>
+            <fraction n="0.60998" ref="N"/>
+            <fraction n="0.087789" ref="H"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_CARBONATE">
+            <D value="2.11" unit="g/cm3"/>
+            <fraction n="0.18785" ref="Li"/>
+            <fraction n="0.162551" ref="C"/>
+            <fraction n="0.649599" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_FLUORIDE">
+            <D value="2.635" unit="g/cm3"/>
+            <fraction n="0.267558" ref="Li"/>
+            <fraction n="0.732442" ref="F"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_HYDRIDE">
+            <D value="0.82" unit="g/cm3"/>
+            <fraction n="0.873183" ref="Li"/>
+            <fraction n="0.126817" ref="H"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_IODIDE">
+            <D value="3.494" unit="g/cm3"/>
+            <fraction n="0.051852" ref="Li"/>
+            <fraction n="0.948148" ref="I"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_OXIDE">
+            <D value="2.013" unit="g/cm3"/>
+            <fraction n="0.464535" ref="Li"/>
+            <fraction n="0.535465" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_TETRABORATE">
+            <D value="2.44" unit="g/cm3"/>
+            <fraction n="0.082072" ref="Li"/>
+            <fraction n="0.255701" ref="B"/>
+            <fraction n="0.662227" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LIVER_ICRP">
+            <D value="1.065" unit="g/cm3"/>
+            <fraction n="0.102" ref="H"/>
+            <fraction n="0.139" ref="C"/>
+            <fraction n="0.03" ref="N"/>
+            <fraction n="0.716" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.003" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.002" ref="Cl"/>
+            <fraction n="0.003" ref="K"/>
+        </material>
+        <material state="solid" name="G4_LUNG_ICRP">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.105" ref="H"/>
+            <fraction n="0.083" ref="C"/>
+            <fraction n="0.023" ref="N"/>
+            <fraction n="0.779" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+        </material>
+        <material state="solid" name="G4_M3_WAX">
+            <D value="1.05" unit="g/cm3"/>
+            <fraction n="0.114318" ref="H"/>
+            <fraction n="0.655824" ref="C"/>
+            <fraction n="0.092183" ref="O"/>
+            <fraction n="0.134792" ref="Mg"/>
+            <fraction n="0.002883" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_MAGNESIUM_CARBONATE">
+            <D value="2.958" unit="g/cm3"/>
+            <fraction n="0.288268" ref="Mg"/>
+            <fraction n="0.142453" ref="C"/>
+            <fraction n="0.569279" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MAGNESIUM_FLUORIDE">
+            <D value="3.0" unit="g/cm3"/>
+            <fraction n="0.390117" ref="Mg"/>
+            <fraction n="0.609883" ref="F"/>
+        </material>
+        <material state="solid" name="G4_MAGNESIUM_OXIDE">
+            <D value="3.58" unit="g/cm3"/>
+            <fraction n="0.603036" ref="Mg"/>
+            <fraction n="0.396964" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MAGNESIUM_TETRABORATE">
+            <D value="2.53" unit="g/cm3"/>
+            <fraction n="0.13537" ref="Mg"/>
+            <fraction n="0.240854" ref="B"/>
+            <fraction n="0.623776" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MERCURIC_IODIDE">
+            <D value="6.36" unit="g/cm3"/>
+            <fraction n="0.441452" ref="Hg"/>
+            <fraction n="0.558548" ref="I"/>
+        </material>
+        <material state="solid" name="G4_SILICUM_OXIDE">
+            <D value="2.65" unit="g/cm3"/>
+            <fraction n="0.467" ref="Si"/>
+            <fraction n="0.532" ref="O"/>
+        </material>
+        <material state="gas" name="G4_METHANE">
+            <D value="6.67151E-4" unit="g/cm3"/>
+            <fraction n="0.748682" ref="C"/>
+            <fraction n="0.251318" ref="H"/>
+        </material>
+        <material state="solid" name="G4_METHANOL">
+            <D value="0.7914" unit="g/cm3"/>
+            <fraction n="0.374845" ref="C"/>
+            <fraction n="0.125828" ref="H"/>
+            <fraction n="0.499327" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MIX_D_WAX">
+            <D value="0.99" unit="g/cm3"/>
+            <fraction n="0.13404" ref="H"/>
+            <fraction n="0.77796" ref="C"/>
+            <fraction n="0.03502" ref="O"/>
+            <fraction n="0.038594" ref="Mg"/>
+            <fraction n="0.014386" ref="Ti"/>
+        </material>
+        <material state="solid" name="G4_MS20_TISSUE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.081192" ref="H"/>
+            <fraction n="0.583442" ref="C"/>
+            <fraction n="0.017798" ref="N"/>
+            <fraction n="0.186381" ref="O"/>
+            <fraction n="0.130287" ref="Mg"/>
+            <fraction n="9.0E-4" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_MUSCLE_SKELETAL_ICRP">
+            <D value="1.05" unit="g/cm3"/>
+            <fraction n="0.102" ref="H"/>
+            <fraction n="0.143" ref="C"/>
+            <fraction n="0.034" ref="N"/>
+            <fraction n="0.71" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.002" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.001" ref="Cl"/>
+            <fraction n="0.004" ref="K"/>
+        </material>
+        <material state="solid" name="G4_MUSCLE_STRIATED_ICRU">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.102102" ref="H"/>
+            <fraction n="0.123123" ref="C"/>
+            <fraction n="0.035035" ref="N"/>
+            <fraction n="0.72973" ref="O"/>
+            <fraction n="0.001001" ref="Na"/>
+            <fraction n="0.002002" ref="P"/>
+            <fraction n="0.004004" ref="S"/>
+            <fraction n="0.003003" ref="K"/>
+        </material>
+        <material state="solid" name="G4_MUSCLE_WITH_SUCROSE">
+            <D value="1.11" unit="g/cm3"/>
+            <fraction n="0.098234" ref="H"/>
+            <fraction n="0.156214" ref="C"/>
+            <fraction n="0.035451" ref="N"/>
+            <fraction n="0.710101" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MUSCLE_WITHOUT_SUCROSE">
+            <D value="1.07" unit="g/cm3"/>
+            <fraction n="0.101969" ref="H"/>
+            <fraction n="0.120058" ref="C"/>
+            <fraction n="0.035451" ref="N"/>
+            <fraction n="0.742522" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NAPHTHALENE">
+            <D value="1.145" unit="g/cm3"/>
+            <fraction n="0.937088" ref="C"/>
+            <fraction n="0.062912" ref="H"/>
+        </material>
+        <material state="solid" name="G4_NITROBENZENE">
+            <D value="1.19867" unit="g/cm3"/>
+            <fraction n="0.585368" ref="C"/>
+            <fraction n="0.040937" ref="H"/>
+            <fraction n="0.113775" ref="N"/>
+            <fraction n="0.259921" ref="O"/>
+        </material>
+        <material state="gas" name="G4_NITROUS_OXIDE">
+            <D value="0.00183094" unit="g/cm3"/>
+            <fraction n="0.636484" ref="N"/>
+            <fraction n="0.363516" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NYLON-8062">
+            <D value="1.08" unit="g/cm3"/>
+            <fraction n="0.103509" ref="H"/>
+            <fraction n="0.648416" ref="C"/>
+            <fraction n="0.099536" ref="N"/>
+            <fraction n="0.148539" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NYLON-6-6">
+            <D value="1.14" unit="g/cm3"/>
+            <fraction n="0.636848" ref="C"/>
+            <fraction n="0.097981" ref="H"/>
+            <fraction n="0.123781" ref="N"/>
+            <fraction n="0.14139" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NYLON-6-10">
+            <D value="1.14" unit="g/cm3"/>
+            <fraction n="0.107062" ref="H"/>
+            <fraction n="0.680449" ref="C"/>
+            <fraction n="0.099189" ref="N"/>
+            <fraction n="0.1133" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NYLON-11_RILSAN">
+            <D value="1.425" unit="g/cm3"/>
+            <fraction n="0.115476" ref="H"/>
+            <fraction n="0.720818" ref="C"/>
+            <fraction n="0.076417" ref="N"/>
+            <fraction n="0.087289" ref="O"/>
+        </material>
+        <material state="solid" name="G4_OCTANE">
+            <D value="0.7026" unit="g/cm3"/>
+            <fraction n="0.84117" ref="C"/>
+            <fraction n="0.15883" ref="H"/>
+        </material>
+        <material state="solid" name="G4_PARAFFIN">
+            <D value="0.93" unit="g/cm3"/>
+            <fraction n="0.851387" ref="C"/>
+            <fraction n="0.148613" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-PENTANE">
+            <D value="0.6262" unit="g/cm3"/>
+            <fraction n="0.832357" ref="C"/>
+            <fraction n="0.167643" ref="H"/>
+        </material>
+        <material state="solid" name="G4_PHOTO_EMULSION">
+            <D value="3.815" unit="g/cm3"/>
+            <fraction n="0.0141" ref="H"/>
+            <fraction n="0.072261" ref="C"/>
+            <fraction n="0.01932" ref="N"/>
+            <fraction n="0.066101" ref="O"/>
+            <fraction n="0.00189" ref="S"/>
+            <fraction n="0.349103" ref="Br"/>
+            <fraction n="0.474105" ref="Ag"/>
+            <fraction n="0.00312" ref="I"/>
+        </material>
+        <material state="solid" name="G4_PLASTIC_SC_VINYLTOLUENE">
+            <D value="1.032" unit="g/cm3"/>
+            <fraction n="0.914709" ref="C"/>
+            <fraction n="0.085291" ref="H"/>
+        </material>
+        <material state="solid" name="G4_PLUTONIUM_DIOXIDE">
+            <D value="11.46" unit="g/cm3"/>
+            <fraction n="0.884089" ref="Pu"/>
+            <fraction n="0.115911" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYACRYLONITRILE">
+            <D value="1.17" unit="g/cm3"/>
+            <fraction n="0.679048" ref="C"/>
+            <fraction n="0.056986" ref="H"/>
+            <fraction n="0.263966" ref="N"/>
+        </material>
+        <material state="solid" name="G4_POLYCARBONATE">
+            <D value="1.2" unit="g/cm3"/>
+            <fraction n="0.755745" ref="C"/>
+            <fraction n="0.055494" ref="H"/>
+            <fraction n="0.18876" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYCHLOROSTYRENE">
+            <D value="1.3" unit="g/cm3"/>
+            <fraction n="0.69329" ref="C"/>
+            <fraction n="0.050908" ref="H"/>
+            <fraction n="0.255802" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_POLYETHYLENE">
+            <D value="0.94" unit="g/cm3"/>
+            <fraction n="0.856282" ref="C"/>
+            <fraction n="0.143718" ref="H"/>
+        </material>
+        <material state="solid" name="G4_MYLAR">
+            <D value="1.4" unit="g/cm3"/>
+            <fraction n="0.625011" ref="C"/>
+            <fraction n="0.041961" ref="H"/>
+            <fraction n="0.333028" ref="O"/>
+        </material>
+        <material state="solid" name="G4_PLEXIGLASS">
+            <D value="1.19" unit="g/cm3"/>
+            <fraction n="0.599841" ref="C"/>
+            <fraction n="0.080542" ref="H"/>
+            <fraction n="0.319617" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYOXYMETHYLENE">
+            <D value="1.425" unit="g/cm3"/>
+            <fraction n="0.400011" ref="C"/>
+            <fraction n="0.067138" ref="H"/>
+            <fraction n="0.532851" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYPROPYLENE">
+            <D value="0.9" unit="g/cm3"/>
+            <fraction n="0.856282" ref="C"/>
+            <fraction n="0.143718" ref="H"/>
+        </material>
+        <material state="solid" name="G4_POLYSTYRENE">
+            <D value="1.06" unit="g/cm3"/>
+            <fraction n="0.922577" ref="C"/>
+            <fraction n="0.077423" ref="H"/>
+        </material>
+        <material state="solid" name="G4_TEFLON">
+            <D value="2.2" unit="g/cm3"/>
+            <fraction n="0.240179" ref="C"/>
+            <fraction n="0.759821" ref="F"/>
+        </material>
+        <material state="solid" name="G4_POLYTRIFLUOROCHLOROETHYLENE">
+            <D value="2.1" unit="g/cm3"/>
+            <fraction n="0.206247" ref="C"/>
+            <fraction n="0.489358" ref="F"/>
+            <fraction n="0.304394" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_ACETATE">
+            <D value="1.19" unit="g/cm3"/>
+            <fraction n="0.558059" ref="C"/>
+            <fraction n="0.070248" ref="H"/>
+            <fraction n="0.371693" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_ALCOHOL">
+            <D value="1.3" unit="g/cm3"/>
+            <fraction n="0.54529" ref="C"/>
+            <fraction n="0.091522" ref="H"/>
+            <fraction n="0.363188" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_BUTYRAL">
+            <D value="1.12" unit="g/cm3"/>
+            <fraction n="0.675729" ref="C"/>
+            <fraction n="0.099238" ref="H"/>
+            <fraction n="0.225033" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_CHLORIDE">
+            <D value="1.3" unit="g/cm3"/>
+            <fraction n="0.384357" ref="C"/>
+            <fraction n="0.048383" ref="H"/>
+            <fraction n="0.567261" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYLIDENE_CHLORIDE">
+            <D value="1.7" unit="g/cm3"/>
+            <fraction n="0.247791" ref="C"/>
+            <fraction n="0.020795" ref="H"/>
+            <fraction n="0.731414" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYLIDENE_FLUORIDE">
+            <D value="1.76" unit="g/cm3"/>
+            <fraction n="0.375135" ref="C"/>
+            <fraction n="0.031481" ref="H"/>
+            <fraction n="0.593383" ref="F"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_PYRROLIDONE">
+            <D value="1.25" unit="g/cm3"/>
+            <fraction n="0.648399" ref="C"/>
+            <fraction n="0.08162" ref="H"/>
+            <fraction n="0.126026" ref="N"/>
+            <fraction n="0.143954" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POTASSIUM_IODIDE">
+            <D value="3.13" unit="g/cm3"/>
+            <fraction n="0.235529" ref="K"/>
+            <fraction n="0.764471" ref="I"/>
+        </material>
+        <material state="solid" name="G4_POTASSIUM_OXIDE">
+            <D value="2.32" unit="g/cm3"/>
+            <fraction n="0.830148" ref="K"/>
+            <fraction n="0.169852" ref="O"/>
+        </material>
+        <material state="gas" name="G4_PROPANE">
+            <D value="0.00187939" unit="g/cm3"/>
+            <fraction n="0.817136" ref="C"/>
+            <fraction n="0.182864" ref="H"/>
+        </material>
+        <material state="solid" name="G4_lPROPANE">
+            <D value="0.43" unit="g/cm3"/>
+            <fraction n="0.817136" ref="C"/>
+            <fraction n="0.182864" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-PROPYL_ALCOHOL">
+            <D value="0.8035" unit="g/cm3"/>
+            <fraction n="0.599586" ref="C"/>
+            <fraction n="0.134179" ref="H"/>
+            <fraction n="0.266234" ref="O"/>
+        </material>
+        <material state="solid" name="G4_PYRIDINE">
+            <D value="0.9819" unit="g/cm3"/>
+            <fraction n="0.759211" ref="C"/>
+            <fraction n="0.063713" ref="H"/>
+            <fraction n="0.177076" ref="N"/>
+        </material>
+        <material state="solid" name="G4_RUBBER_BUTYL">
+            <D value="0.92" unit="g/cm3"/>
+            <fraction n="0.143711" ref="H"/>
+            <fraction n="0.856289" ref="C"/>
+        </material>
+        <material state="solid" name="G4_RUBBER_NATURAL">
+            <D value="0.92" unit="g/cm3"/>
+            <fraction n="0.118371" ref="H"/>
+            <fraction n="0.881629" ref="C"/>
+        </material>
+        <material state="solid" name="G4_RUBBER_NEOPRENE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.05692" ref="H"/>
+            <fraction n="0.542646" ref="C"/>
+            <fraction n="0.400434" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_SILICON_DIOXIDE">
+            <D value="2.32" unit="g/cm3"/>
+            <fraction n="0.467434" ref="Si"/>
+            <fraction n="0.532566" ref="O"/>
+        </material>
+        <material state="solid" name="G4_SILVER_BROMIDE">
+            <D value="6.473" unit="g/cm3"/>
+            <fraction n="0.574465" ref="Ag"/>
+            <fraction n="0.425535" ref="Br"/>
+        </material>
+        <material state="solid" name="G4_SILVER_CHLORIDE">
+            <D value="5.56" unit="g/cm3"/>
+            <fraction n="0.752635" ref="Ag"/>
+            <fraction n="0.247365" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_SILVER_HALIDES">
+            <D value="6.47" unit="g/cm3"/>
+            <fraction n="0.422895" ref="Br"/>
+            <fraction n="0.573748" ref="Ag"/>
+            <fraction n="0.003357" ref="I"/>
+        </material>
+        <material state="solid" name="G4_SILVER_IODIDE">
+            <D value="6.01" unit="g/cm3"/>
+            <fraction n="0.459459" ref="Ag"/>
+            <fraction n="0.540541" ref="I"/>
+        </material>
+        <material state="solid" name="G4_SKIN_ICRP">
+            <D value="1.09" unit="g/cm3"/>
+            <fraction n="0.1" ref="H"/>
+            <fraction n="0.204" ref="C"/>
+            <fraction n="0.042" ref="N"/>
+            <fraction n="0.645" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.001" ref="K"/>
+        </material>
+        <material state="solid" name="G4_SODIUM_CARBONATE">
+            <D value="2.532" unit="g/cm3"/>
+            <fraction n="0.433817" ref="Na"/>
+            <fraction n="0.113321" ref="C"/>
+            <fraction n="0.452862" ref="O"/>
+        </material>
+        <material state="solid" name="G4_SODIUM_IODIDE">
+            <D value="3.667" unit="g/cm3"/>
+            <fraction n="0.153374" ref="Na"/>
+            <fraction n="0.846626" ref="I"/>
+        </material>
+        <material state="solid" name="G4_SODIUM_MONOXIDE">
+            <D value="2.27" unit="g/cm3"/>
+            <fraction n="0.741858" ref="Na"/>
+            <fraction n="0.258142" ref="O"/>
+        </material>
+        <material state="solid" name="G4_SODIUM_NITRATE">
+            <D value="2.261" unit="g/cm3"/>
+            <fraction n="0.270485" ref="Na"/>
+            <fraction n="0.164796" ref="N"/>
+            <fraction n="0.564719" ref="O"/>
+        </material>
+        <material state="solid" name="G4_STILBENE">
+            <D value="0.9707" unit="g/cm3"/>
+            <fraction n="0.932896" ref="C"/>
+            <fraction n="0.067104" ref="H"/>
+        </material>
+        <material state="solid" name="G4_SUCROSE">
+            <D value="1.5805" unit="g/cm3"/>
+            <fraction n="0.421064" ref="C"/>
+            <fraction n="0.064782" ref="H"/>
+            <fraction n="0.514154" ref="O"/>
+        </material>
+        <material state="solid" name="G4_TERPHENYL">
+            <D value="1.24" unit="g/cm3"/>
+            <fraction n="0.938728" ref="C"/>
+            <fraction n="0.061272" ref="H"/>
+        </material>
+        <material state="solid" name="G4_TESTIS_ICRP">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.106" ref="H"/>
+            <fraction n="0.099" ref="C"/>
+            <fraction n="0.02" ref="N"/>
+            <fraction n="0.766" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.002" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+        </material>
+        <material state="solid" name="G4_TETRACHLOROETHYLENE">
+            <D value="1.625" unit="g/cm3"/>
+            <fraction n="0.144854" ref="C"/>
+            <fraction n="0.855146" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_THALLIUM_CHLORIDE">
+            <D value="7.004" unit="g/cm3"/>
+            <fraction n="0.85218" ref="Tl"/>
+            <fraction n="0.14782" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_TISSUE_SOFT_ICRP">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.105" ref="H"/>
+            <fraction n="0.256" ref="C"/>
+            <fraction n="0.027" ref="N"/>
+            <fraction n="0.602" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.002" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.002" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+        </material>
+        <material state="solid" name="G4_TISSUE_SOFT_ICRU-4">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.101" ref="H"/>
+            <fraction n="0.111" ref="C"/>
+            <fraction n="0.026" ref="N"/>
+            <fraction n="0.762" ref="O"/>
+        </material>
+        <material state="gas" name="G4_TISSUE-METHANE">
+            <D value="0.00106409" unit="g/cm3"/>
+            <fraction n="0.101869" ref="H"/>
+            <fraction n="0.456179" ref="C"/>
+            <fraction n="0.035172" ref="N"/>
+            <fraction n="0.40678" ref="O"/>
+        </material>
+        <material state="gas" name="G4_TISSUE-PROPANE">
+            <D value="0.00182628" unit="g/cm3"/>
+            <fraction n="0.102672" ref="H"/>
+            <fraction n="0.56894" ref="C"/>
+            <fraction n="0.035022" ref="N"/>
+            <fraction n="0.293366" ref="O"/>
+        </material>
+        <material state="solid" name="G4_TITANIUM_DIOXIDE">
+            <D value="4.26" unit="g/cm3"/>
+            <fraction n="0.599342" ref="Ti"/>
+            <fraction n="0.400658" ref="O"/>
+        </material>
+        <material state="solid" name="G4_TOLUENE">
+            <D value="0.8669" unit="g/cm3"/>
+            <fraction n="0.912485" ref="C"/>
+            <fraction n="0.087515" ref="H"/>
+        </material>
+        <material state="solid" name="G4_TRICHLOROETHYLENE">
+            <D value="1.46" unit="g/cm3"/>
+            <fraction n="0.18283" ref="C"/>
+            <fraction n="0.007672" ref="H"/>
+            <fraction n="0.809499" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_TRIETHYL_PHOSPHATE">
+            <D value="1.07" unit="g/cm3"/>
+            <fraction n="0.395622" ref="C"/>
+            <fraction n="0.083001" ref="H"/>
+            <fraction n="0.351336" ref="O"/>
+            <fraction n="0.170041" ref="P"/>
+        </material>
+        <material state="solid" name="G4_TUNGSTEN_HEXAFLUORIDE">
+            <D value="2.4" unit="g/cm3"/>
+            <fraction n="0.617266" ref="W"/>
+            <fraction n="0.382734" ref="F"/>
+        </material>
+        <material state="solid" name="G4_URANIUM_DICARBIDE">
+            <D value="11.28" unit="g/cm3"/>
+            <fraction n="0.908333" ref="U"/>
+            <fraction n="0.091667" ref="C"/>
+        </material>
+        <material state="solid" name="G4_URANIUM_MONOCARBIDE">
+            <D value="13.63" unit="g/cm3"/>
+            <fraction n="0.951965" ref="U"/>
+            <fraction n="0.048035" ref="C"/>
+        </material>
+        <material state="solid" name="G4_URANIUM_OXIDE">
+            <D value="10.96" unit="g/cm3"/>
+            <fraction n="0.881498" ref="U"/>
+            <fraction n="0.118502" ref="O"/>
+        </material>
+        <material state="solid" name="G4_UREA">
+            <D value="1.323" unit="g/cm3"/>
+            <fraction n="0.199994" ref="C"/>
+            <fraction n="0.067134" ref="H"/>
+            <fraction n="0.466461" ref="N"/>
+            <fraction n="0.26641" ref="O"/>
+        </material>
+        <material state="solid" name="G4_VALINE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.512637" ref="C"/>
+            <fraction n="0.094645" ref="H"/>
+            <fraction n="0.119566" ref="N"/>
+            <fraction n="0.273152" ref="O"/>
+        </material>
+        <material state="solid" name="G4_VITON">
+            <D value="1.8" unit="g/cm3"/>
+            <fraction n="0.009417" ref="H"/>
+            <fraction n="0.280555" ref="C"/>
+            <fraction n="0.710028" ref="F"/>
+        </material>
+        <material state="gas" name="G4_WATER_VAPOR">
+            <D value="7.56182E-4" unit="g/cm3"/>
+            <fraction n="0.111898" ref="H"/>
+            <fraction n="0.888102" ref="O"/>
+        </material>
+        <material state="solid" name="G4_XYLENE">
+            <D value="0.87" unit="g/cm3"/>
+            <fraction n="0.905059" ref="C"/>
+            <fraction n="0.094941" ref="H"/>
+        </material>
+        <material state="solid" name="G4_GRAPHITE">
+            <D value="2.21" unit="g/cm3"/>
+            <fraction n="1.0" ref="C"/>
+        </material>
+        <material state="liquid" name="G4_lH2">
+            <D value="0.0708" unit="g/cm3"/>
+            <fraction n="1.0" ref="H"/>
+        </material>
+        <material state="liquid" name="G4_lN2">
+            <D value="0.807" unit="g/cm3"/>
+            <fraction n="1.0" ref="N"/>
+        </material>
+        <material state="liquid" name="G4_lO2">
+            <D value="1.141" unit="g/cm3"/>
+            <fraction n="1.0" ref="O"/>
+        </material>
+        <material state="liquid" name="G4_lAr">
+            <D value="1.396" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ar"/>
+        </material>
+        <material state="liquid" name="G4_lBr">
+            <D value="3.1028" unit="g/cm3"/>
+            <fraction n="1.0" ref="Br"/>
+        </material>
+        <material state="liquid" name="G4_lKr">
+            <D value="2.418" unit="g/cm3"/>
+            <fraction n="1.0" ref="Kr"/>
+        </material>
+        <material state="liquid" name="G4_lXe">
+            <D value="2.953" unit="g/cm3"/>
+            <fraction n="1.0" ref="Xe"/>
+        </material>
+        <material state="solid" name="G4_PbWO4">
+            <D value="8.28" unit="g/cm3"/>
+            <fraction n="0.140637" ref="O"/>
+            <fraction n="0.455366" ref="Pb"/>
+            <fraction n="0.403998" ref="W"/>
+        </material>
+        <material state="gas" name="G4_Galactic">
+            <D value="1.0E-25" unit="g/cm3"/>
+            <fraction n="1.0" ref="H"/>
+        </material>
+        <material state="solid" name="G4_GRAPHITE_POROUS">
+            <D value="1.7" unit="g/cm3"/>
+            <fraction n="1.0" ref="C"/>
+        </material>
+        <material state="solid" name="G4_LUCITE">
+            <D value="1.19" unit="g/cm3"/>
+            <fraction n="0.080538" ref="H"/>
+            <fraction n="0.599848" ref="C"/>
+            <fraction n="0.319614" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BRASS">
+            <D value="8.52" unit="g/cm3"/>
+            <fraction n="0.57513" ref="Cu"/>
+            <fraction n="0.334122" ref="Zn"/>
+            <fraction n="0.090748" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_BRONZE">
+            <D value="8.82" unit="g/cm3"/>
+            <fraction n="0.849368" ref="Cu"/>
+            <fraction n="0.088391" ref="Zn"/>
+            <fraction n="0.062241" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_STAINLESS-STEEL">
+            <D value="8.0" unit="g/cm3"/>
+            <fraction n="0.746213" ref="Fe"/>
+            <fraction n="0.169001" ref="Cr"/>
+            <fraction n="0.084786" ref="Ni"/>
+        </material>
+        <material state="solid" name="G4_CR39">
+            <D value="1.32" unit="g/cm3"/>
+            <fraction n="0.066151" ref="H"/>
+            <fraction n="0.525505" ref="C"/>
+            <fraction n="0.408345" ref="O"/>
+        </material>
+        <material state="solid" name="G4_OCTADECANOL">
+            <D value="0.812" unit="g/cm3"/>
+            <fraction n="0.141599" ref="H"/>
+            <fraction n="0.799252" ref="C"/>
+            <fraction n="0.059149" ref="O"/>
+        </material>
+        <material state="solid" name="G4_KEVLAR">
+            <D value="1.44" unit="g/cm3"/>
+            <fraction n="0.705796" ref="C"/>
+            <fraction n="0.042307" ref="H"/>
+            <fraction n="0.134312" ref="O"/>
+            <fraction n="0.117584" ref="N"/>
+        </material>
+        <material state="solid" name="G4_DACRON">
+            <D value="1.4" unit="g/cm3"/>
+            <fraction n="0.625011" ref="C"/>
+            <fraction n="0.041961" ref="H"/>
+            <fraction n="0.333028" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NEOPRENE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.542642" ref="C"/>
+            <fraction n="0.056923" ref="H"/>
+            <fraction n="0.400435" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_CYTOSINE">
+            <D value="1.55" unit="g/cm3"/>
+            <fraction n="0.045361" ref="H"/>
+            <fraction n="0.432421" ref="C"/>
+            <fraction n="0.378213" ref="N"/>
+            <fraction n="0.144006" ref="O"/>
+        </material>
+        <material state="solid" name="G4_THYMINE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.047954" ref="H"/>
+            <fraction n="0.476187" ref="C"/>
+            <fraction n="0.222129" ref="N"/>
+            <fraction n="0.25373" ref="O"/>
+        </material>
+        <material state="solid" name="G4_URACIL">
+            <D value="1.32" unit="g/cm3"/>
+            <fraction n="0.03597" ref="H"/>
+            <fraction n="0.428622" ref="C"/>
+            <fraction n="0.249927" ref="N"/>
+            <fraction n="0.285482" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DEOXYRIBOSE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.085324" ref="H"/>
+            <fraction n="0.508364" ref="C"/>
+            <fraction n="0.406312" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_DEOXYRIBOSE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.084896" ref="H"/>
+            <fraction n="0.722592" ref="C"/>
+            <fraction n="0.192512" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_PHOSPHATE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.326138" ref="P"/>
+            <fraction n="0.673862" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_ADENINE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.030061" ref="H"/>
+            <fraction n="0.447763" ref="C"/>
+            <fraction n="0.522176" ref="N"/>
+        </material>
+        <material state="solid" name="G4_DNA_GUANINE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.026857" ref="H"/>
+            <fraction n="0.400041" ref="C"/>
+            <fraction n="0.466523" ref="N"/>
+            <fraction n="0.106578" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_CYTOSINE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.036621" ref="H"/>
+            <fraction n="0.43638" ref="C"/>
+            <fraction n="0.381675" ref="N"/>
+            <fraction n="0.145324" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_THYMINE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.040284" ref="H"/>
+            <fraction n="0.480024" ref="C"/>
+            <fraction n="0.223919" ref="N"/>
+            <fraction n="0.255774" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_URACIL">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.027222" ref="H"/>
+            <fraction n="0.432511" ref="C"/>
+            <fraction n="0.252195" ref="N"/>
+            <fraction n="0.288072" ref="O"/>
+        </material>
+        <material state="gas" name="Vacuum">
+            <D value="1.0E-20" unit="g/cm3"/>
+            <fraction n="0.7" ref="G4_N"/>
+            <fraction n="0.3" ref="G4_O"/>
+        </material>
+        <material state="solid" name="BC408">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.085" ref="G4_H"/>
+            <fraction n="0.915" ref="G4_C"/>
+        </material>
+        <material state="solid" name="PVT">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.085" ref="G4_H"/>
+            <fraction n="0.915" ref="G4_C"/>
+        </material>
+        <element name="6Li">
+            <fraction n="1.0" ref="Li6"/>
+        </element>
+        <material state="solid" name="6LiI">
+            <D value="3.494" unit="g/cm3"/>
+            <fraction n="0.045113" ref="6Li"/>
+            <fraction n="0.954887" ref="I"/>
+        </material>
+        <material state="solid" name="LUNG20_AIR80">
+            <D value="0.209" unit="g/cm3"/>
+            <fraction n="0.2" ref="G4_LUNG_ICRP"/>
+            <fraction n="0.8" ref="G4_AIR"/>
+        </material>
+        <material state="solid" name="BoratedHDPE5pct">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.05" ref="G4_B"/>
+            <fraction n="0.95" ref="G4_POLYETHYLENE"/>
+        </material>
+        <material state="solid" name="BoratedHDPE1pct">
+            <D value="0.96" unit="g/cm3"/>
+            <fraction n="0.01" ref="G4_B"/>
+            <fraction n="0.99" ref="G4_POLYETHYLENE"/>
+        </material>
+        <material state="solid" name="EJ254-5pct">
+            <D value="1.026" unit="g/cm3"/>
+            <fraction n="0.084647652" ref="G4_H"/>
+            <fraction n="0.865300985" ref="G4_C"/>
+            <fraction n="0.050051363" ref="G4_B"/>
+        </material>
+        <material state="solid" name="EJ254-2.5pct">
+            <D value="1.023" unit="g/cm3"/>
+            <fraction n="0.084809873" ref="G4_H"/>
+            <fraction n="0.890156445" ref="G4_C"/>
+            <fraction n="0.025033682" ref="G4_B"/>
+        </material>
+        <material state="solid" name="EJ254-1pct">
+            <D value="1.021" unit="g/cm3"/>
+            <fraction n="0.084766095" ref="G4_H"/>
+            <fraction n="0.905135339" ref="G4_C"/>
+            <fraction n="0.010098567" ref="G4_B"/>
+        </material>
+        <material state="solid" name="mirrobor_B4C">
+            <D value="1.55" unit="g/cm3"/>
+            <fraction n="0.2080661841" ref="G4_C"/>
+            <fraction n="0.7919338159" ref="G4_B"/>
+        </material>
+        <material state="solid" name="mirrobor_additives">
+            <D value="1.55" unit="g/cm3"/>
+            <fraction n="0.7" ref="G4_C"/>
+            <fraction n="0.25" ref="G4_O"/>
+            <fraction n="0.05" ref="G4_H"/>
+        </material>
+        <material state="solid" name="mirrobor">
+            <D value="1.55" unit="g/cm3"/>
+            <fraction n="0.8" ref="mirrobor_B4C"/>
+            <fraction n="0.2" ref="mirrobor_additives"/>
+        </material>
+        <material state="liquid" name="LiquidScintillatorBase">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.085" ref="G4_H"/>
+            <fraction n="0.915" ref="G4_C"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator1pctPb">
+            <D value="1.1332" unit="g/cm3"/>
+            <fraction n="0.01" ref="G4_Pb"/>
+            <fraction n="0.99" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator2pctPb">
+            <D value="1.2364" unit="g/cm3"/>
+            <fraction n="0.02" ref="G4_Pb"/>
+            <fraction n="0.98" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator3pctPb">
+            <D value="1.3396" unit="g/cm3"/>
+            <fraction n="0.03" ref="G4_Pb"/>
+            <fraction n="0.97" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator4pctPb">
+            <D value="1.4428" unit="g/cm3"/>
+            <fraction n="0.04" ref="G4_Pb"/>
+            <fraction n="0.96" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator5pctPb">
+            <D value="1.546" unit="g/cm3"/>
+            <fraction n="0.05" ref="G4_Pb"/>
+            <fraction n="0.95" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator6pctPb">
+            <D value="1.6492" unit="g/cm3"/>
+            <fraction n="0.06" ref="G4_Pb"/>
+            <fraction n="0.94" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator7pctPb">
+            <D value="1.7524" unit="g/cm3"/>
+            <fraction n="0.07" ref="G4_Pb"/>
+            <fraction n="0.93" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator8pctPb">
+            <D value="1.8556" unit="g/cm3"/>
+            <fraction n="0.08" ref="G4_Pb"/>
+            <fraction n="0.92" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator9pctPb">
+            <D value="1.9588" unit="g/cm3"/>
+            <fraction n="0.09" ref="G4_Pb"/>
+            <fraction n="0.91" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator10pctPb">
+            <D value="2.062" unit="g/cm3"/>
+            <fraction n="0.1" ref="G4_Pb"/>
+            <fraction n="0.9" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator11pctPb">
+            <D value="2.1652" unit="g/cm3"/>
+            <fraction n="0.11" ref="G4_Pb"/>
+            <fraction n="0.89" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator12pctPb">
+            <D value="2.2684" unit="g/cm3"/>
+            <fraction n="0.12" ref="G4_Pb"/>
+            <fraction n="0.88" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator13pctPb">
+            <D value="2.3716" unit="g/cm3"/>
+            <fraction n="0.13" ref="G4_Pb"/>
+            <fraction n="0.87" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator14pctPb">
+            <D value="2.4748" unit="g/cm3"/>
+            <fraction n="0.14" ref="G4_Pb"/>
+            <fraction n="0.86" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator15pctPb">
+            <D value="2.578" unit="g/cm3"/>
+            <fraction n="0.15" ref="G4_Pb"/>
+            <fraction n="0.85" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator16pctPb">
+            <D value="2.6812" unit="g/cm3"/>
+            <fraction n="0.16" ref="G4_Pb"/>
+            <fraction n="0.84" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator17pctPb">
+            <D value="2.7844" unit="g/cm3"/>
+            <fraction n="0.17" ref="G4_Pb"/>
+            <fraction n="0.83" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator18pctPb">
+            <D value="2.8876" unit="g/cm3"/>
+            <fraction n="0.18" ref="G4_Pb"/>
+            <fraction n="0.82" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator19pctPb">
+            <D value="2.9908" unit="g/cm3"/>
+            <fraction n="0.19" ref="G4_Pb"/>
+            <fraction n="0.81" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator20pctPb">
+            <D value="3.094" unit="g/cm3"/>
+            <fraction n="0.2" ref="G4_Pb"/>
+            <fraction n="0.8" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator21pctPb">
+            <D value="3.1972" unit="g/cm3"/>
+            <fraction n="0.21" ref="G4_Pb"/>
+            <fraction n="0.79" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator22pctPb">
+            <D value="3.3004" unit="g/cm3"/>
+            <fraction n="0.22" ref="G4_Pb"/>
+            <fraction n="0.78" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator23pctPb">
+            <D value="3.4036" unit="g/cm3"/>
+            <fraction n="0.23" ref="G4_Pb"/>
+            <fraction n="0.77" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator24pctPb">
+            <D value="3.5068" unit="g/cm3"/>
+            <fraction n="0.24" ref="G4_Pb"/>
+            <fraction n="0.76" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator25pctPb">
+            <D value="3.61" unit="g/cm3"/>
+            <fraction n="0.25" ref="G4_Pb"/>
+            <fraction n="0.75" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator26pctPb">
+            <D value="3.7132" unit="g/cm3"/>
+            <fraction n="0.26" ref="G4_Pb"/>
+            <fraction n="0.74" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator27pctPb">
+            <D value="3.8164" unit="g/cm3"/>
+            <fraction n="0.27" ref="G4_Pb"/>
+            <fraction n="0.73" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator28pctPb">
+            <D value="3.9196" unit="g/cm3"/>
+            <fraction n="0.28" ref="G4_Pb"/>
+            <fraction n="0.72" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator29pctPb">
+            <D value="4.0228" unit="g/cm3"/>
+            <fraction n="0.29" ref="G4_Pb"/>
+            <fraction n="0.71" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator30pctPb">
+            <D value="4.126" unit="g/cm3"/>
+            <fraction n="0.3" ref="G4_Pb"/>
+            <fraction n="0.7" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator31pctPb">
+            <D value="4.2292" unit="g/cm3"/>
+            <fraction n="0.31" ref="G4_Pb"/>
+            <fraction n="0.69" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator32pctPb">
+            <D value="4.3324" unit="g/cm3"/>
+            <fraction n="0.32" ref="G4_Pb"/>
+            <fraction n="0.68" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator33pctPb">
+            <D value="4.4356" unit="g/cm3"/>
+            <fraction n="0.33" ref="G4_Pb"/>
+            <fraction n="0.67" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator34pctPb">
+            <D value="4.5388" unit="g/cm3"/>
+            <fraction n="0.34" ref="G4_Pb"/>
+            <fraction n="0.66" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator35pctPb">
+            <D value="4.642" unit="g/cm3"/>
+            <fraction n="0.35" ref="G4_Pb"/>
+            <fraction n="0.65" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator36pctPb">
+            <D value="4.7452" unit="g/cm3"/>
+            <fraction n="0.36" ref="G4_Pb"/>
+            <fraction n="0.64" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator37pctPb">
+            <D value="4.8484" unit="g/cm3"/>
+            <fraction n="0.37" ref="G4_Pb"/>
+            <fraction n="0.63" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator38pctPb">
+            <D value="4.9516" unit="g/cm3"/>
+            <fraction n="0.38" ref="G4_Pb"/>
+            <fraction n="0.62" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator39pctPb">
+            <D value="5.0548" unit="g/cm3"/>
+            <fraction n="0.39" ref="G4_Pb"/>
+            <fraction n="0.61" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator40pctPb">
+            <D value="5.158" unit="g/cm3"/>
+            <fraction n="0.4" ref="G4_Pb"/>
+            <fraction n="0.6" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator41pctPb">
+            <D value="5.2612" unit="g/cm3"/>
+            <fraction n="0.41" ref="G4_Pb"/>
+            <fraction n="0.59" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator42pctPb">
+            <D value="5.3644" unit="g/cm3"/>
+            <fraction n="0.42" ref="G4_Pb"/>
+            <fraction n="0.58" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator43pctPb">
+            <D value="5.4676" unit="g/cm3"/>
+            <fraction n="0.43" ref="G4_Pb"/>
+            <fraction n="0.57" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator44pctPb">
+            <D value="5.5708" unit="g/cm3"/>
+            <fraction n="0.44" ref="G4_Pb"/>
+            <fraction n="0.56" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator45pctPb">
+            <D value="5.674" unit="g/cm3"/>
+            <fraction n="0.45" ref="G4_Pb"/>
+            <fraction n="0.55" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator46pctPb">
+            <D value="5.7772" unit="g/cm3"/>
+            <fraction n="0.46" ref="G4_Pb"/>
+            <fraction n="0.54" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator47pctPb">
+            <D value="5.8804" unit="g/cm3"/>
+            <fraction n="0.47" ref="G4_Pb"/>
+            <fraction n="0.53" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator48pctPb">
+            <D value="5.9836" unit="g/cm3"/>
+            <fraction n="0.48" ref="G4_Pb"/>
+            <fraction n="0.52" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator49pctPb">
+            <D value="6.0868" unit="g/cm3"/>
+            <fraction n="0.49" ref="G4_Pb"/>
+            <fraction n="0.51" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator50pctPb">
+            <D value="6.19" unit="g/cm3"/>
+            <fraction n="0.5" ref="G4_Pb"/>
+            <fraction n="0.5" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator51pctPb">
+            <D value="6.2932" unit="g/cm3"/>
+            <fraction n="0.51" ref="G4_Pb"/>
+            <fraction n="0.49" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator52pctPb">
+            <D value="6.3964" unit="g/cm3"/>
+            <fraction n="0.52" ref="G4_Pb"/>
+            <fraction n="0.48" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator53pctPb">
+            <D value="6.4996" unit="g/cm3"/>
+            <fraction n="0.53" ref="G4_Pb"/>
+            <fraction n="0.47" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator54pctPb">
+            <D value="6.6028" unit="g/cm3"/>
+            <fraction n="0.54" ref="G4_Pb"/>
+            <fraction n="0.46" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator55pctPb">
+            <D value="6.706" unit="g/cm3"/>
+            <fraction n="0.55" ref="G4_Pb"/>
+            <fraction n="0.45" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator56pctPb">
+            <D value="6.8092" unit="g/cm3"/>
+            <fraction n="0.56" ref="G4_Pb"/>
+            <fraction n="0.44" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator57pctPb">
+            <D value="6.9124" unit="g/cm3"/>
+            <fraction n="0.57" ref="G4_Pb"/>
+            <fraction n="0.43" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator58pctPb">
+            <D value="7.0156" unit="g/cm3"/>
+            <fraction n="0.58" ref="G4_Pb"/>
+            <fraction n="0.42" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator59pctPb">
+            <D value="7.1188" unit="g/cm3"/>
+            <fraction n="0.59" ref="G4_Pb"/>
+            <fraction n="0.41" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator60pctPb">
+            <D value="7.222" unit="g/cm3"/>
+            <fraction n="0.6" ref="G4_Pb"/>
+            <fraction n="0.4" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator61pctPb">
+            <D value="7.3252" unit="g/cm3"/>
+            <fraction n="0.61" ref="G4_Pb"/>
+            <fraction n="0.39" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator62pctPb">
+            <D value="7.4284" unit="g/cm3"/>
+            <fraction n="0.62" ref="G4_Pb"/>
+            <fraction n="0.38" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator63pctPb">
+            <D value="7.5316" unit="g/cm3"/>
+            <fraction n="0.63" ref="G4_Pb"/>
+            <fraction n="0.37" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator64pctPb">
+            <D value="7.6348" unit="g/cm3"/>
+            <fraction n="0.64" ref="G4_Pb"/>
+            <fraction n="0.36" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator65pctPb">
+            <D value="7.738" unit="g/cm3"/>
+            <fraction n="0.65" ref="G4_Pb"/>
+            <fraction n="0.35" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator66pctPb">
+            <D value="7.8412" unit="g/cm3"/>
+            <fraction n="0.66" ref="G4_Pb"/>
+            <fraction n="0.34" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator67pctPb">
+            <D value="7.9444" unit="g/cm3"/>
+            <fraction n="0.67" ref="G4_Pb"/>
+            <fraction n="0.33" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator68pctPb">
+            <D value="8.0476" unit="g/cm3"/>
+            <fraction n="0.68" ref="G4_Pb"/>
+            <fraction n="0.32" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator69pctPb">
+            <D value="8.1508" unit="g/cm3"/>
+            <fraction n="0.69" ref="G4_Pb"/>
+            <fraction n="0.31" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator70pctPb">
+            <D value="8.254" unit="g/cm3"/>
+            <fraction n="0.7" ref="G4_Pb"/>
+            <fraction n="0.3" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator71pctPb">
+            <D value="8.3572" unit="g/cm3"/>
+            <fraction n="0.71" ref="G4_Pb"/>
+            <fraction n="0.29" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator72pctPb">
+            <D value="8.4604" unit="g/cm3"/>
+            <fraction n="0.72" ref="G4_Pb"/>
+            <fraction n="0.28" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator73pctPb">
+            <D value="8.5636" unit="g/cm3"/>
+            <fraction n="0.73" ref="G4_Pb"/>
+            <fraction n="0.27" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator74pctPb">
+            <D value="8.6668" unit="g/cm3"/>
+            <fraction n="0.74" ref="G4_Pb"/>
+            <fraction n="0.26" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator75pctPb">
+            <D value="8.77" unit="g/cm3"/>
+            <fraction n="0.75" ref="G4_Pb"/>
+            <fraction n="0.25" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator76pctPb">
+            <D value="8.8732" unit="g/cm3"/>
+            <fraction n="0.76" ref="G4_Pb"/>
+            <fraction n="0.24" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator77pctPb">
+            <D value="8.9764" unit="g/cm3"/>
+            <fraction n="0.77" ref="G4_Pb"/>
+            <fraction n="0.23" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator78pctPb">
+            <D value="9.0796" unit="g/cm3"/>
+            <fraction n="0.78" ref="G4_Pb"/>
+            <fraction n="0.22" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator79pctPb">
+            <D value="9.1828" unit="g/cm3"/>
+            <fraction n="0.79" ref="G4_Pb"/>
+            <fraction n="0.21" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator80pctPb">
+            <D value="9.286" unit="g/cm3"/>
+            <fraction n="0.8" ref="G4_Pb"/>
+            <fraction n="0.2" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator81pctPb">
+            <D value="9.3892" unit="g/cm3"/>
+            <fraction n="0.81" ref="G4_Pb"/>
+            <fraction n="0.19" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator82pctPb">
+            <D value="9.4924" unit="g/cm3"/>
+            <fraction n="0.82" ref="G4_Pb"/>
+            <fraction n="0.18" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator83pctPb">
+            <D value="9.5956" unit="g/cm3"/>
+            <fraction n="0.83" ref="G4_Pb"/>
+            <fraction n="0.17" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator84pctPb">
+            <D value="9.6988" unit="g/cm3"/>
+            <fraction n="0.84" ref="G4_Pb"/>
+            <fraction n="0.16" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator85pctPb">
+            <D value="9.802" unit="g/cm3"/>
+            <fraction n="0.85" ref="G4_Pb"/>
+            <fraction n="0.15" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator86pctPb">
+            <D value="9.9052" unit="g/cm3"/>
+            <fraction n="0.86" ref="G4_Pb"/>
+            <fraction n="0.14" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator87pctPb">
+            <D value="10.0084" unit="g/cm3"/>
+            <fraction n="0.87" ref="G4_Pb"/>
+            <fraction n="0.13" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator88pctPb">
+            <D value="10.1116" unit="g/cm3"/>
+            <fraction n="0.88" ref="G4_Pb"/>
+            <fraction n="0.12" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator89pctPb">
+            <D value="10.2148" unit="g/cm3"/>
+            <fraction n="0.89" ref="G4_Pb"/>
+            <fraction n="0.11" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator90pctPb">
+            <D value="10.318" unit="g/cm3"/>
+            <fraction n="0.9" ref="G4_Pb"/>
+            <fraction n="0.1" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator91pctPb">
+            <D value="10.4212" unit="g/cm3"/>
+            <fraction n="0.91" ref="G4_Pb"/>
+            <fraction n="0.09" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator92pctPb">
+            <D value="10.5244" unit="g/cm3"/>
+            <fraction n="0.92" ref="G4_Pb"/>
+            <fraction n="0.08" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator93pctPb">
+            <D value="10.6276" unit="g/cm3"/>
+            <fraction n="0.93" ref="G4_Pb"/>
+            <fraction n="0.07" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator94pctPb">
+            <D value="10.7308" unit="g/cm3"/>
+            <fraction n="0.94" ref="G4_Pb"/>
+            <fraction n="0.06" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator95pctPb">
+            <D value="10.834" unit="g/cm3"/>
+            <fraction n="0.95" ref="G4_Pb"/>
+            <fraction n="0.05" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator96pctPb">
+            <D value="10.9372" unit="g/cm3"/>
+            <fraction n="0.96" ref="G4_Pb"/>
+            <fraction n="0.04" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator97pctPb">
+            <D value="11.0404" unit="g/cm3"/>
+            <fraction n="0.97" ref="G4_Pb"/>
+            <fraction n="0.03" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator98pctPb">
+            <D value="11.1436" unit="g/cm3"/>
+            <fraction n="0.98" ref="G4_Pb"/>
+            <fraction n="0.02" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator99pctPb">
+            <D value="11.2468" unit="g/cm3"/>
+            <fraction n="0.99" ref="G4_Pb"/>
+            <fraction n="0.01" ref="LiquidScintillatorBase"/>
+        </material>
+        <material state="gas" name="TMAGas">
+            <D value="6.7" unit="kg/m3"/>
+            <fraction n="0.6095775385572637" ref="C"/>
+            <fraction n="0.1534682886203227" ref="H"/>
+            <fraction n="0.2369541728224135" ref="N"/>
+        </material>
+        <material state="gas" name="IsobutaneGas">
+            <D value="2.38467" unit="kg/m3"/>
+            <fraction n="0.8265819278538703" ref="C"/>
+            <fraction n="0.1734180721461297" ref="H"/>
+        </material>
+        <material state="gas" name="HeliumGas">
+            <D value="0.125" unit="kg/m3"/>
+            <fraction n="1.0" ref="He"/>
+        </material>
+        <material state="gas" name="XenonGas">
+            <D value="5.894" unit="kg/m3"/>
+            <fraction n="1.0" ref="Xe"/>
+        </material>
+        <material state="gas" name="ArgonGas">
+            <D value="1.63897" unit="kg/m3"/>
+            <fraction n="1.0" ref="Ar"/>
+        </material>
+        <material state="gas" name="Xenon50Neon50Gas">
+            <D value="3.0553" unit="kg/m3"/>
+            <fraction n="0.8667868153341387" ref="Xe"/>
+            <fraction n="0.1332131846658613" ref="Ne"/>
+        </material>
+        <material state="gas" name="Argon1%Isobutane1bar">
+            <D value="1.61882" unit="kg/m3"/>
+            <fraction n="0.9855" ref="ArgonGas"/>
+            <fraction n="0.0145" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="Argon2%Isobutane1bar">
+            <D value="1.62615" unit="kg/m3"/>
+            <fraction n="0.9711" ref="ArgonGas"/>
+            <fraction n="0.0289" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="Argon3%Isobutane1bar">
+            <D value="1.63348" unit="kg/m3"/>
+            <fraction n="0.9569" ref="ArgonGas"/>
+            <fraction n="0.0431" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="Argon4%Isobutane1bar">
+            <D value="1.64081" unit="kg/m3"/>
+            <fraction n="0.9428" ref="ArgonGas"/>
+            <fraction n="0.0572" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="Argon5%Isobutane1bar">
+            <D value="1.64814" unit="kg/m3"/>
+            <fraction n="0.9288" ref="ArgonGas"/>
+            <fraction n="0.0712" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="Argon10%Isobutane1bar">
+            <D value="1.6848" unit="kg/m3"/>
+            <fraction n="0.8608" ref="ArgonGas"/>
+            <fraction n="0.1392" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="XenonNeon1%Isobutane1bar">
+            <D value="3.04819" unit="kg/m3"/>
+            <fraction n="0.99230795006" ref="Xenon50Neon50Gas"/>
+            <fraction n="0.00769204994" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="XenonNeon2.3%Isobutane1bar">
+            <D value="3.03895" unit="kg/m3"/>
+            <fraction n="0.98225450491" ref="Xenon50Neon50Gas"/>
+            <fraction n="0.01774549509" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="XenonNeon5%Isobutane1bar">
+            <D value="3.01977" unit="kg/m3"/>
+            <fraction n="0.961177731" ref="Xenon50Neon50Gas"/>
+            <fraction n="0.038822269" ref="IsobutaneGas"/>
+        </material>
+        <material state="gas" name="Argon1%Isobutane1.2bar">
+            <D value="1.942584" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon1%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon2%Isobutane1.2bar">
+            <D value="1.95138" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon2%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon3%Isobutane1.2bar">
+            <D value="1.960176" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon4%Isobutane1.2bar">
+            <D value="1.968972" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon4%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon5%Isobutane1.2bar">
+            <D value="1.977768" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon5%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon10%Isobutane1.2bar">
+            <D value="2.02176" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon10%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon1%Isobutane1.4bar">
+            <D value="2.266348" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon1%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon2%Isobutane1.4bar">
+            <D value="2.27661" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon2%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon3%Isobutane1.4bar">
+            <D value="2.286872" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon4%Isobutane1.4bar">
+            <D value="2.297134" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon4%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon5%Isobutane1.4bar">
+            <D value="2.307396" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon5%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon10%Isobutane1.4bar">
+            <D value="2.35872" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon10%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon1%Isobutane1.5bar">
+            <D value="2.42836" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon1%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon2%Isobutane1.5bar">
+            <D value="2.43936" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon2%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon3%Isobutane1.5bar">
+            <D value="2.45036" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon4%Isobutane1.5bar">
+            <D value="2.46136" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon4%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon5%Isobutane1.5bar">
+            <D value="2.47235" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon5%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon10%Isobutane1.5bar">
+            <D value="2.52735" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon10%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon1%Isobutane1.6bar">
+            <D value="2.590112" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon1%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon2%Isobutane1.6bar">
+            <D value="2.60184" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon2%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon3%Isobutane1.6bar">
+            <D value="2.613568" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon4%Isobutane1.6bar">
+            <D value="2.625296" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon4%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon5%Isobutane1.6bar">
+            <D value="2.637024" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon5%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon10%Isobutane1.6bar">
+            <D value="2.69568" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon10%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon1%Isobutane2.0bar">
+            <D value="3.23781" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon1%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon2%Isobutane2.0bar">
+            <D value="3.25248" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon2%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon3%Isobutane2.0bar">
+            <D value="3.26714" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon4%Isobutane2.0bar">
+            <D value="3.28181" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon4%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon5%Isobutane2.0bar">
+            <D value="3.29647" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon5%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="Argon10%Isobutane2.0bar">
+            <D value="3.3698" unit="kg/m3"/>
+            <fraction n="1.0" ref="Argon10%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="XenonNeon2.3%Isobutane1.05bar">
+            <D value="3.1908975" unit="kg/m3"/>
+            <fraction n="1.0" ref="XenonNeon2.3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="XenonNeon2.3%Isobutane1.5bar">
+            <D value="4.5585" unit="kg/m3"/>
+            <fraction n="1.0" ref="XenonNeon2.3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="XenonNeon2.3%Isobutane2.0bar">
+            <D value="6.078" unit="kg/m3"/>
+            <fraction n="1.0" ref="XenonNeon2.3%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="XenonNeon5%Isobutane1.5bar">
+            <D value="4.52972" unit="kg/m3"/>
+            <fraction n="1.0" ref="XenonNeon5%Isobutane1bar"/>
+        </material>
+        <material state="gas" name="XenonNeon5%Isobutane2.0bar">
+            <D value="6.03963" unit="kg/m3"/>
+            <fraction n="1.0" ref="XenonNeon5%Isobutane1bar"/>
+        </material>
+        <material state="solid" name="Copper">
+            <D value="8.96" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cu"/>
+        </material>
+        <material state="solid" name="Lead">
+            <D value="11.35" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pb"/>
+        </material>
+        <material state="solid" name="Aluminium">
+            <D value="2.699" unit="g/cm3"/>
+            <fraction n="1.0" ref="Al"/>
+        </material>
+        <material state="solid" name="Cadmium">
+            <D value="8.65" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cd"/>
+        </material>
+        <material state="solid" name="Steel">
+            <D value="8.0" unit="g/cm3"/>
+            <fraction n="0.746213" ref="Fe"/>
+            <fraction n="0.169001" ref="Cr"/>
+            <fraction n="0.084786" ref="Ni"/>
+        </material>
+        <material state="solid" name="StainlessSteel">
+            <D value="8.0" unit="g/cm3"/>
+            <fraction n="0.746213" ref="Fe"/>
+            <fraction n="0.169001" ref="Cr"/>
+            <fraction n="0.084786" ref="Ni"/>
+        </material>
+        <material state="solid" name="Water">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.111898" ref="H"/>
+            <fraction n="0.888102" ref="O"/>
+        </material>
+        <material state="gas" name="Air">
+            <D value="0.00120479" unit="g/cm3"/>
+            <fraction n="1.24E-4" ref="C"/>
+            <fraction n="0.755268" ref="N"/>
+            <fraction n="0.231781" ref="O"/>
+            <fraction n="0.012827" ref="Ar"/>
+        </material>
+    </materials>
+    <solids>
+        <box lunit="mm" aunit="rad" name="chamberBodyBaseSolid" x="134.0" y="134.0" z="30.0"/>
+        <tube lunit="mm" aunit="rad" name="chamberBodyHoleSolid" rmax="51.0" z="30.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="chamberBodySolid">
+            <first ref="chamberBodyBaseSolid"/>
+            <second ref="chamberBodyHoleSolid"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="chamberBackplateSolid" x="134.0" y="134.0" z="15.0"/>
+        <tube lunit="mm" aunit="rad" name="chamberTeflonWallSolid" rmax="51.0" z="30.0" rmin="50.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <box lunit="mm" aunit="rad" name="kaptonReadoutSolid" x="134.0" y="134.0" z="0.5"/>
+        <box lunit="mm" aunit="rad" name="copperReadoutSolid" x="60.0" y="60.0" z="0.2"/>
+        <tube lunit="mm" aunit="rad" name="cathodeTeflonDiskBaseSolid" rmax="67.0" z="5.0" rmin="15.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="cathodeCopperDiskSolid" rmax="45.0" z="1.0" rmin="8.5" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="cathodeTeflonDiskSolid">
+            <position name="cathodeTeflonDiskSolid.position" z="-2.0" unit="mm"/>
+            <first ref="cathodeTeflonDiskBaseSolid"/>
+            <second ref="cathodeCopperDiskSolid"/>
+        </subtraction>
+        <tube lunit="mm" aunit="rad" name="cathodeWindowMylarSolid" rmax="15.0" z="0.00396" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="cathodeWindowAluminiumSolid" rmax="15.0" z="4.0E-5" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <box lunit="mm" aunit="rad" name="cathodePatternLineAux" x="0.3" y="17.0" z="1.0"/>
+        <tube lunit="mm" aunit="rad" name="cathodePatternCentralHole" rmax="4.25" z="1.1" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="cathodePatternLine">
+            <first ref="cathodePatternLineAux"/>
+            <second ref="cathodePatternCentralHole"/>
+        </subtraction>
+        <tube lunit="mm" aunit="rad" name="cathodePatternDisk" rmax="4.25" z="1.0" rmin="3.95" startphi="0.0" deltaphi="6.283185307179586"/>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskSolidAux0">
+            <rotation name="cathodeCopperDiskSolidAux0.rotation" unit="deg"/>
+            <first ref="cathodeCopperDiskSolid"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskSolidAux1">
+            <rotation name="cathodeCopperDiskSolidAux1.rotation" z="45.0" unit="deg"/>
+            <first ref="cathodeCopperDiskSolidAux0"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskSolidAux2">
+            <rotation name="cathodeCopperDiskSolidAux2.rotation" z="90.0" unit="deg"/>
+            <first ref="cathodeCopperDiskSolidAux1"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskSolidAux3">
+            <rotation name="cathodeCopperDiskSolidAux3.rotation" z="135.0" unit="deg"/>
+            <first ref="cathodeCopperDiskSolidAux2"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskFinal.solid">
+            <first ref="cathodeCopperDiskSolidAux3"/>
+            <second ref="cathodePatternDisk"/>
+        </union>
+        <tube lunit="mm" aunit="rad" name="cathodeFillingBaseSolid" rmax="15.0" z="5.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="cathodeFillingSolid">
+            <position name="cathodeFillingSolid.position" z="-2.0" unit="mm"/>
+            <first ref="cathodeFillingBaseSolid"/>
+            <second ref="cathodeCopperDiskFinal.solid"/>
+        </subtraction>
+        <tube lunit="mm" aunit="rad" name="gasSolidOriginal" rmax="50.0" z="30.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidAux1">
+            <position name="gasSolidAux1.position" z="-14.9" unit="mm"/>
+            <rotation name="gasSolidAux1.rotation" z="45.0" unit="deg"/>
+            <first ref="gasSolidOriginal"/>
+            <second ref="copperReadoutSolid"/>
+        </subtraction>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidAux2">
+            <position name="gasSolidAux2.position" z="14.996020000000001" unit="mm"/>
+            <first ref="gasSolidAux1"/>
+            <second ref="cathodeWindowAluminiumSolid"/>
+        </subtraction>
+        <subtraction lunit="mm" aunit="rad" name="gasSolid">
+            <position name="gasSolid.position" z="14.99802" unit="mm"/>
+            <first ref="gasSolidAux2"/>
+            <second ref="cathodeWindowMylarSolid"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="gasSolidAboveReadoutOriginal" x="60.0" y="60.0" z="30.0"/>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidAboveReadoutAux">
+            <position name="gasSolidAboveReadoutAux.position" z="-14.9" unit="mm"/>
+            <rotation name="gasSolidAboveReadoutAux.rotation" z="45.0" unit="deg"/>
+            <first ref="gasSolidAboveReadoutOriginal"/>
+            <second ref="copperReadoutSolid"/>
+        </subtraction>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidAboveReadoutAux2">
+            <position name="gasSolidAboveReadoutAux2.position" z="14.996020000000001" unit="mm"/>
+            <first ref="gasSolidAboveReadoutAux"/>
+            <second ref="cathodeWindowAluminiumSolid"/>
+        </subtraction>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidAboveReadoutSolid">
+            <position name="gasSolidAboveReadoutSolid.position" z="14.99802" unit="mm"/>
+            <first ref="gasSolidAboveReadoutAux2"/>
+            <second ref="cathodeWindowMylarSolid"/>
+        </subtraction>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidWithHole">
+            <rotation name="gasSolidWithHole.rotation" z="45.0" unit="deg"/>
+            <first ref="gasSolid"/>
+            <second ref="gasSolidAboveReadoutSolid"/>
+        </subtraction>
+        <tube lunit="mm" aunit="rad" name="detectorPipeChamberFlangeSolid" rmax="67.0" z="14.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeTelescopeFlangeSolid" rmax="75.0" z="18.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeSection1of2Solid" rmax="46.0" z="327.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeSection2of2Solid" rmax="54.0" z="132.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <union lunit="mm" aunit="rad" name="detectorPipeAux1">
+            <position name="detectorPipeAux1.position" z="170.5" unit="mm"/>
+            <first ref="detectorPipeChamberFlangeSolid"/>
+            <second ref="detectorPipeSection1of2Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeAux2">
+            <position name="detectorPipeAux2.position" z="400.0" unit="mm"/>
+            <first ref="detectorPipeAux1"/>
+            <second ref="detectorPipeSection2of2Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeNotEmpty">
+            <position name="detectorPipeNotEmpty.position" z="475.0" unit="mm"/>
+            <first ref="detectorPipeAux2"/>
+            <second ref="detectorPipeTelescopeFlangeSolid"/>
+        </union>
+        <tube lunit="mm" aunit="rad" name="detectorPipeInside1of3Solid" rmax="21.5" z="179.35" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeInside2of3Solid" rmax="34.0" z="160.28" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeInside3of3Solid" rmax="42.5" z="106.5" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <cone lunit="mm" aunit="rad" name="detectorPipeInsideCone1of3Solid" z="21.65" rmax1="21.5" rmax2="34.0" deltaphi="6.283185307179586"/>
+        <cone lunit="mm" aunit="rad" name="detectorPipeInsideCone2of3Solid" z="14.72" rmax1="34.0" rmax2="42.5" deltaphi="6.283185307179586"/>
+        <cone lunit="mm" aunit="rad" name="detectorPipeInsideCone3of3Solid" z="8.5" rmax1="42.5" rmax2="54.0" deltaphi="6.283185307179586"/>
+        <union lunit="mm" aunit="rad" name="detectorPipeInsideAux1">
+            <position name="detectorPipeInsideAux1.position" z="100.5" unit="mm"/>
+            <first ref="detectorPipeInside1of3Solid"/>
+            <second ref="detectorPipeInsideCone1of3Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeInsideAux2">
+            <position name="detectorPipeInsideAux2.position" z="191.465" unit="mm"/>
+            <first ref="detectorPipeInsideAux1"/>
+            <second ref="detectorPipeInside2of3Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeInsideAux3">
+            <position name="detectorPipeInsideAux3.position" z="278.96500000000003" unit="mm"/>
+            <first ref="detectorPipeInsideAux2"/>
+            <second ref="detectorPipeInsideCone2of3Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeInsideAux4">
+            <position name="detectorPipeInsideAux4.position" z="339.57500000000005" unit="mm"/>
+            <first ref="detectorPipeInsideAux3"/>
+            <second ref="detectorPipeInside3of3Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeInside">
+            <position name="detectorPipeInside.position" z="397.07500000000005" unit="mm"/>
+            <first ref="detectorPipeInsideAux4"/>
+            <second ref="detectorPipeInsideCone3of3Solid"/>
+        </union>
+        <subtraction lunit="mm" aunit="rad" name="detectorPipeSolid">
+            <position name="detectorPipeSolid.position" z="82.675" unit="mm"/>
+            <first ref="detectorPipeNotEmpty"/>
+            <second ref="detectorPipeInside"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsBoxOutSolid" x="41.0" y="90.0" z="200.0"/>
+        <box lunit="mm" aunit="rad" name="electronicsBoxInSolid" x="31.0" y="80.0" z="190.0"/>
+        <subtraction lunit="mm" aunit="rad" name="electronicsBoxSolid">
+            <first ref="electronicsBoxOutSolid"/>
+            <second ref="electronicsBoxInSolid"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
+        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="chipSolid" x="1.0" y="25.0" z="25.0"/>
+        <box lunit="mm" aunit="rad" name="componentsSolid" x="1.0" y="40.0" z="5.0"/>
+        <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
+        <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
+        <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
+            <position name="copperBoxSolid.position" z="10.0" unit="mm"/>
+            <first ref="copperBoxOuterSolid"/>
+            <second ref="copperBoxInnerSolid"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="leadBoxSolid" x="600.0" y="600.0" z="550.0"/>
+        <box lunit="mm" aunit="rad" name="leadBoxShaftSolid" x="200.0" y="200.0" z="350.0"/>
+        <subtraction lunit="mm" aunit="rad" name="leadBoxWithShaftSolid">
+            <position name="leadBoxWithShaftSolid.position" z="100.0" unit="mm"/>
+            <first ref="leadBoxSolid"/>
+            <second ref="leadBoxShaftSolid"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="worldBox" x="1350.0" y="1350.0" z="3000.0"/>
+    </solids>
+    <structure>
+        <volume name="chamberBodyVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="chamberBodySolid"/>
+        </volume>
+        <volume name="chamberBackplateVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="chamberBackplateSolid"/>
+        </volume>
+        <volume name="chamberTeflonWallVolume">
+            <materialref ref="G4_TEFLON"/>
+            <solidref ref="chamberTeflonWallSolid"/>
+        </volume>
+        <volume name="kaptonReadoutVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="kaptonReadoutSolid"/>
+        </volume>
+        <volume name="copperReadoutVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="copperReadoutSolid"/>
+        </volume>
+        <volume name="cathodeTeflonDiskVolume">
+            <materialref ref="G4_TEFLON"/>
+            <solidref ref="cathodeTeflonDiskSolid"/>
+        </volume>
+        <volume name="cathodeWindowMylarVolume">
+            <materialref ref="G4_MYLAR"/>
+            <solidref ref="cathodeWindowMylarSolid"/>
+        </volume>
+        <volume name="cathodeWindowAluminiumVolume">
+            <materialref ref="G4_Al"/>
+            <solidref ref="cathodeWindowAluminiumSolid"/>
+        </volume>
+        <volume name="cathodeCopperDiskFinal">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="cathodeCopperDiskFinal.solid"/>
+        </volume>
+        <volume name="cathodeFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="cathodeFillingSolid"/>
+        </volume>
+        <volume name="gasVolume">
+            <materialref ref="Argon1%Isobutane1.4bar"/>
+            <solidref ref="gasSolid"/>
+        </volume>
+        <volume name="gasVolumeNotAboveReadout">
+            <materialref ref="Argon1%Isobutane1.4bar"/>
+            <solidref ref="gasSolidWithHole"/>
+        </volume>
+        <volume name="gasVolumeAboveReadout">
+            <materialref ref="Argon1%Isobutane1.4bar"/>
+            <solidref ref="gasSolidAboveReadoutSolid"/>
+        </volume>
+        <assembly name="Chamber">
+            <physvol name="gasNotAboveReadout">
+                <volumeref ref="gasVolumeNotAboveReadout"/>
+            </physvol>
+            <physvol name="gasAboveReadout">
+                <volumeref ref="gasVolumeAboveReadout"/>
+                <rotation name="gasAboveReadout.rotation" z="45.0" unit="deg"/>
+            </physvol>
+            <physvol name="chamberBackplate">
+                <volumeref ref="chamberBackplateVolume"/>
+                <position name="chamberBackplate.position" z="-23.0" unit="mm"/>
+            </physvol>
+            <physvol name="chamberBody">
+                <volumeref ref="chamberBodyVolume"/>
+            </physvol>
+            <physvol name="chamberTeflonWall">
+                <volumeref ref="chamberTeflonWallVolume"/>
+            </physvol>
+            <physvol name="kaptonReadout">
+                <volumeref ref="kaptonReadoutVolume"/>
+                <position name="kaptonReadout.position" z="-15.25" unit="mm"/>
+            </physvol>
+            <physvol name="copperReadout">
+                <volumeref ref="copperReadoutVolume"/>
+                <position name="copperReadout.position" z="-14.9" unit="mm"/>
+                <rotation name="copperReadout.rotation" z="45.0" unit="deg"/>
+            </physvol>
+            <physvol name="cathodeWindowMylar">
+                <volumeref ref="cathodeWindowMylarVolume"/>
+                <position name="cathodeWindowMylar.position" z="14.99802" unit="mm"/>
+            </physvol>
+            <physvol name="cathodeWindowAluminium">
+                <volumeref ref="cathodeWindowAluminiumVolume"/>
+                <position name="cathodeWindowAluminium.position" z="14.996020000000001" unit="mm"/>
+            </physvol>
+            <physvol name="cathodeTeflonDisk">
+                <volumeref ref="cathodeTeflonDiskVolume"/>
+                <position name="cathodeTeflonDisk.position" z="17.5" unit="mm"/>
+            </physvol>
+            <physvol name="cathodeFilling">
+                <volumeref ref="cathodeFillingVolume"/>
+                <position name="cathodeFilling.position" z="17.5" unit="mm"/>
+            </physvol>
+            <physvol name="cathodeCopperDiskPattern">
+                <volumeref ref="cathodeCopperDiskFinal"/>
+                <position name="cathodeCopperDiskPattern.position" z="15.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="detectorPipeVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="detectorPipeSolid"/>
+        </volume>
+        <volume name="detectorPipeFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="detectorPipeInside"/>
+        </volume>
+        <assembly name="detectorPipe">
+            <physvol name="detectorPipe">
+                <volumeref ref="detectorPipeVolume"/>
+            </physvol>
+            <physvol name="detectorPipeFilling">
+                <volumeref ref="detectorPipeFillingVolume"/>
+                <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="electronicsBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsBoxSolid"/>
+        </volume>
+        <volume name="electronicsBoxFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="electronicsBoxInSolid"/>
+        </volume>
+        <volume name="electronicsCardVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="electronicsCardSolid"/>
+        </volume>
+        <volume name="flatCableVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="flatCableSolid"/>
+        </volume>
+        <volume name="chipVolume">
+            <materialref ref="G4_Si"/>
+            <solidref ref="chipSolid"/>
+        </volume>
+        <volume name="componentsVolume">
+            <materialref ref="G4_Si"/>
+            <solidref ref="componentsSolid"/>
+        </volume>
+        <assembly name="electronicsBox">
+            <physvol name="electronicsCard1">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard2">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard3">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            </physvol>
+            <physvol name="electronicsCard4">
+                <volumeref ref="electronicsCardVolume"/>
+                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            </physvol>
+            <physvol name="chip1">
+                <volumeref ref="chipVolume"/>
+                <position name="chip1.position" x="-13.25" unit="mm"/>
+            </physvol>
+            <physvol name="chip2">
+                <volumeref ref="chipVolume"/>
+                <position name="chip2.position" x="-3.25" unit="mm"/>
+            </physvol>
+            <physvol name="chip3">
+                <volumeref ref="chipVolume"/>
+                <position name="chip3.position" x="6.75" unit="mm"/>
+            </physvol>
+            <physvol name="chip4">
+                <volumeref ref="chipVolume"/>
+                <position name="chip4.position" x="16.75" unit="mm"/>
+            </physvol>
+            <physvol name="components1">
+                <volumeref ref="componentsVolume"/>
+                <position name="components1.position" x="-13.25" z="-30.0" unit="mm"/>
+            </physvol>
+            <physvol name="components2">
+                <volumeref ref="componentsVolume"/>
+                <position name="components2.position" x="-3.25" z="-30.0" unit="mm"/>
+            </physvol>
+            <physvol name="components3">
+                <volumeref ref="componentsVolume"/>
+                <position name="components3.position" x="6.75" z="-30.0" unit="mm"/>
+            </physvol>
+            <physvol name="components4">
+                <volumeref ref="componentsVolume"/>
+                <position name="components4.position" x="16.75" z="-30.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatCable1">
+                <volumeref ref="flatCableVolume"/>
+                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatCable2">
+                <volumeref ref="flatCableVolume"/>
+                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatCable3">
+                <volumeref ref="flatCableVolume"/>
+                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            </physvol>
+            <physvol name="flatCable4">
+                <volumeref ref="flatCableVolume"/>
+                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="copperBoxVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="copperBoxSolid"/>
+        </volume>
+        <volume name="shieldingVolume">
+            <materialref ref="G4_Pb"/>
+            <solidref ref="leadBoxWithShaftSolid"/>
+        </volume>
+        <assembly name="shielding">
+            <physvol name="shieldingLead">
+                <volumeref ref="shieldingVolume"/>
+                <position name="shieldingLead.position" z="19.5" unit="mm"/>
+            </physvol>
+            <physvol name="copperBox">
+                <volumeref ref="copperBoxVolume"/>
+                <position name="copperBox.position" z="119.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="world">
+            <physvol name="Chamber">
+                <volumeref ref="Chamber"/>
+            </physvol>
+            <physvol name="DetectorPipe">
+                <volumeref ref="detectorPipe"/>
+                <position name="DetectorPipe.position" z="27.0" unit="mm"/>
+            </physvol>
+            <physvol name="ElectronicsBox">
+                <volumeref ref="electronicsBox"/>
+                <position name="ElectronicsBox.position" x="66.5" z="235.0" unit="mm"/>
+            </physvol>
+            <physvol name="Shielding">
+                <volumeref ref="shielding"/>
+            </physvol>
+            <materialref ref="G4_AIR"/>
+            <solidref ref="worldBox"/>
+        </volume>
+    </structure>
+    <setup name="Default" version="1.0">
+        <world ref="world"/>
+    </setup>
+</gdml>

--- a/gdml/IAXO-D1/NoVetoesGasNotSplit.gdml
+++ b/gdml/IAXO-D1/NoVetoesGasNotSplit.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxOuterSolid" x="200.0" y="200.0" z="350.0"/>
         <box lunit="mm" aunit="rad" name="copperBoxInnerSolid" x="180.0" y="150.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="copperBoxSolid">
@@ -4283,46 +4283,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="copperBoxVolume">

--- a/gdml/IAXO-D1/ShieldingLayers.gdml
+++ b/gdml/IAXO-D1/ShieldingLayers.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerBox1" x="220.0" y="220.0" z="360.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerHole1" x="200.0" y="200.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="shieldingLayerBoxWithHole1">
@@ -4420,46 +4420,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="shieldingVolumeLayer1">

--- a/gdml/IAXO-D1/ShieldingLayersNoCopperBox.gdml
+++ b/gdml/IAXO-D1/ShieldingLayersNoCopperBox.gdml
@@ -4143,8 +4143,8 @@
             <first ref="electronicsBoxOutSolid"/>
             <second ref="electronicsBoxInSolid"/>
         </subtraction>
-        <box lunit="mm" aunit="rad" name="electronicsCardSolid" x="2.5" y="70.0" z="100.0"/>
-        <box lunit="mm" aunit="rad" name="flatCableSolid" x="1.0" y="70.0" z="150.0"/>
+        <box lunit="mm" aunit="rad" name="SAFECSolid" x="0.31" y="102.6" z="226.94"/>
+        <box lunit="mm" aunit="rad" name="SAFEC_MMSolid" x="0.1" y="102.25" z="141.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerBox1" x="220.0" y="220.0" z="360.0"/>
         <box lunit="mm" aunit="rad" name="shieldingLayerHole1" x="200.0" y="200.0" z="350.0"/>
         <subtraction lunit="mm" aunit="rad" name="shieldingLayerBoxWithHole1">
@@ -4420,46 +4420,86 @@
             <materialref ref="G4_Galactic"/>
             <solidref ref="electronicsBoxInSolid"/>
         </volume>
-        <volume name="electronicsCardVolume">
-            <materialref ref="G4_Cu"/>
-            <solidref ref="electronicsCardSolid"/>
+        <volume name="kaptonSAFECVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFECSolid"/>
         </volume>
-        <volume name="flatCableVolume">
+        <volume name="copperSAFECVolume">
             <materialref ref="G4_Cu"/>
-            <solidref ref="flatCableSolid"/>
+            <solidref ref="SAFECSolid"/>
+        </volume>
+        <volume name="copperSAFEC_MMVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="SAFEC_MMSolid"/>
+        </volume>
+        <volume name="kaptonSAFEC_MMVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="SAFEC_MMSolid"/>
         </volume>
         <assembly name="electronicsBox">
-            <physvol name="electronicsCard1">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard1.position" x="-15.0" unit="mm"/>
+            <physvol name="copperSAFEC1">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC1.position" x="-15.155" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard2">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard2.position" x="-5.0" unit="mm"/>
+            <physvol name="kaptonSAFEC1">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC1.position" x="-14.845" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard3">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard3.position" x="5.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM1">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM1.position" x="-14.639999999999999" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="electronicsCard4">
-                <volumeref ref="electronicsCardVolume"/>
-                <position name="electronicsCard4.position" x="15.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM1">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM1.position" x="-14.54" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable1">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable1.position" x="-15.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC2">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC2.position" x="-5.155" unit="mm"/>
             </physvol>
-            <physvol name="flatCable2">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable2.position" x="-5.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC2">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC2.position" x="-4.845" unit="mm"/>
             </physvol>
-            <physvol name="flatCable3">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable3.position" x="5.0" z="-125.0" unit="mm"/>
+            <physvol name="copperSAFEC_MM2">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM2.position" x="-4.640000000000001" z="-128.76999999999998" unit="mm"/>
             </physvol>
-            <physvol name="flatCable4">
-                <volumeref ref="flatCableVolume"/>
-                <position name="flatCable4.position" x="15.0" z="-125.0" unit="mm"/>
+            <physvol name="kaptonSAFEC_MM2">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM2.position" x="-4.54" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC3">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC3.position" x="4.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC3">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC3.position" x="5.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM3">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM3.position" x="5.359999999999999" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM3">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM3.position" x="5.46" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC4">
+                <volumeref ref="copperSAFECVolume"/>
+                <position name="copperSAFEC4.position" x="14.845" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC4">
+                <volumeref ref="kaptonSAFECVolume"/>
+                <position name="kaptonSAFEC4.position" x="15.155" unit="mm"/>
+            </physvol>
+            <physvol name="copperSAFEC_MM4">
+                <volumeref ref="copperSAFEC_MMVolume"/>
+                <position name="copperSAFEC_MM4.position" x="15.360000000000001" z="-128.76999999999998" unit="mm"/>
+            </physvol>
+            <physvol name="kaptonSAFEC_MM4">
+                <volumeref ref="kaptonSAFEC_MMVolume"/>
+                <position name="kaptonSAFEC_MM4.position" x="15.46" z="-128.76999999999998" unit="mm"/>
             </physvol>
         </assembly>
         <volume name="shieldingVolumeLayer1">

--- a/generator/src/main/kotlin/BabyIAXO/Electronics.kt
+++ b/generator/src/main/kotlin/BabyIAXO/Electronics.kt
@@ -15,26 +15,27 @@ open class Electronics (
         const val electronicsBoxShortSideY: Double = 90.0
         const val electronicsBoxThickness: Double = 5.0
 
-        //Card Dimensions
-        const val cardLongSizeZ: Double = 100.0
-        const val cardShortSideX: Double = 2.5
-        const val cardShortSideY: Double = 70.0
+        //Card (SAFEC) Dimensions
+        const val SAFECLongSideZ: Double = 226.94
+        const val SAFECShortSideX: Double = 0.62
+        const val SAFECShortSideY: Double = 102.6
 
-        //flat cable Dimensions
-        const val flatCableLongSideZ: Double = 150.0
-        const val flatCableShortSideX: Double = 1.0
-        const val flatCableShortSideY: Double = 70.0
+        //flat cable (SAFEC_MM) Dimensions
+        const val SAFEC_MMLongSideZ: Double = 141.0 //had to reduce 20.0 mm to avoid overlap with pipe
+        const val SAFEC_MMShortSideX: Double = 0.2
+        const val SAFEC_MMShortSideY: Double = 102.25
 
         //chip Dimensions
-        const val chipSideYZ: Double = 25.0
+        const val chipSideYZ: Double = 28.0
         const val chipShortSideX: Double = 1.0
 
         //components Dimensions
-        const val componentsLongSideZ: Double = 5.0
-        const val componentsShortSideX: Double = 1.0
-        const val componentsShortSideY: Double = 40.0
+        const val componentsSideZ: Double = 9.3
+        const val componentsSideX: Double = 1.0
+        const val componentsSideY: Double = 76.2
 
         // Distance 
+        const val SAFECLimandeContactDistance: Double = 55.2
         const val DetectorToElectronicsDistanceZ: Double = 235.0
         const val PipeToElectronicsOffSetX: Double = 5.0
         const val PipeToElectronicsDistanceX: Double = 82.0 - (electronicsBoxShortSideX / 2) + PipeToElectronicsOffSetX
@@ -67,18 +68,18 @@ open class Electronics (
                 "electronicsBoxSolid")
 
             //Card
-            val electronicsCardSolid = gdml.solids.box(
-                cardShortSideX,
-                cardShortSideY,
-                cardLongSizeZ,
-                "electronicsCardSolid")
+            val SAFECSolid = gdml.solids.box(
+                SAFECShortSideX/2,
+                SAFECShortSideY,
+                SAFECLongSideZ,
+                "SAFECSolid")
 
             //Flat cable
-            val flatCableSolid = gdml.solids.box(
-                flatCableShortSideX,
-                flatCableShortSideY,
-                flatCableLongSideZ,
-                "flatCableSolid")
+            val SAFEC_MMSolid = gdml.solids.box(
+                SAFEC_MMShortSideX/2,
+                SAFEC_MMShortSideY,
+                SAFEC_MMLongSideZ,
+                "SAFEC_MMSolid")
 
             val electronicsBoxVolume = 
             gdml.structure.volume(Materials.Copper.ref,electronicsBoxSolid,"electronicsBoxVolume")
@@ -86,41 +87,53 @@ open class Electronics (
             val electronicsBoxFillingVolume =
             gdml.structure.volume(Materials.Vacuum.ref,electronicsBoxInSolid,"electronicsBoxFillingVolume")
 
-            val electronicsCardVolume = 
-            gdml.structure.volume(Materials.Copper.ref,electronicsCardSolid,"electronicsCardVolume")
+            val kaptonSAFECVolume = 
+            gdml.structure.volume(Materials.Kapton.ref,SAFECSolid,"kaptonSAFECVolume")
+            val copperSAFECVolume = 
+            gdml.structure.volume(Materials.Copper.ref,SAFECSolid,"copperSAFECVolume")
 
-            val flatCableVolume =
-            gdml.structure.volume(Materials.Copper.ref,flatCableSolid,"flatCableVolume")
+            val copperSAFEC_MMVolume =
+            gdml.structure.volume(Materials.Copper.ref,SAFEC_MMSolid,"copperSAFEC_MMVolume")
+            val kaptonSAFEC_MMVolume =
+            gdml.structure.volume(Materials.Kapton.ref,SAFEC_MMSolid,"kaptonSAFEC_MMVolume")
 
             return@lazy gdml.structure.assembly {
                 name = "electronicsBox"
                 //physVolume(electronicsBoxVolume, name = "electronicsBox")
                 //physVolume(electronicsBoxFillingVolume, name = "electronicsBoxFilling")
 
-                physVolume(electronicsCardVolume, name = "electronicsCard1"){
-                    position(x = - 15.0 ) { unit = LUnit.MM }
-                }
-                physVolume(electronicsCardVolume, name = "electronicsCard2"){
-                    position(x = - 5.0 ) { unit = LUnit.MM }
-                }
-                physVolume(electronicsCardVolume, name = "electronicsCard3"){
-                    position(x = 5.0 ) { unit = LUnit.MM }
-                }
-                physVolume(electronicsCardVolume, name = "electronicsCard4"){
-                    position(x = 15.0 ) { unit = LUnit.MM }
-                }
+                val positionsX = listOf(-15.0, -5.0, 5.0, 15.0)
 
-                physVolume(flatCableVolume, name = "flatCable1"){
-                    position(x = - 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
-                physVolume(flatCableVolume, name = "flatCable2"){
-                    position(x = - 5.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
-                physVolume(flatCableVolume, name = "flatCable3"){
-                    position(x = 5.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
-                physVolume(flatCableVolume, name = "flatCable4"){
-                    position(x = 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
+                //SAFEC: copperSAFEC{i} + kaptonSAFEC{i}
+                //SAFEC_MM: copperSAFEC_MM{i} + kaptonSAFEC_MM{i}
+                for (i in positionsX.indices) {
+                    val posX = positionsX[i]
+                    val copperName = "copperSAFEC${i + 1}"
+                    val kaptonName = "kaptonSAFEC${i + 1}"
+                    val coppersafecMMName = "copperSAFEC_MM${i + 1}"
+                    val kaptonsafecMMName = "kaptonSAFEC_MM${i + 1}"
+
+                    physVolume(copperSAFECVolume, name = copperName) {
+                        position(x = posX - SAFECShortSideX / 4) { unit = LUnit.MM }
+                    }
+
+                    physVolume(kaptonSAFECVolume, name = kaptonName) {
+                        position(x = posX + SAFECShortSideX / 4) { unit = LUnit.MM }
+                    }
+
+                    physVolume(copperSAFEC_MMVolume, name = coppersafecMMName) {
+                        position(
+                            x = posX + SAFECShortSideX / 2 + SAFEC_MMShortSideX / 4,
+                            z = -SAFECLongSideZ / 2 - SAFEC_MMLongSideZ / 2 + SAFECLimandeContactDistance
+                        ) { unit = LUnit.MM }
+                    }
+
+                    physVolume(kaptonSAFEC_MMVolume, name = kaptonsafecMMName) {
+                        position(
+                            x = posX + SAFECShortSideX / 2 + 3*SAFEC_MMShortSideX / 4,
+                            z = -SAFECLongSideZ / 2 - SAFEC_MMLongSideZ / 2 + SAFECLimandeContactDistance
+                        ) { unit = LUnit.MM }
+                    }
                 }
                 }
             }
@@ -150,18 +163,18 @@ open class Electronics (
                 "electronicsBoxSolid")
 
             //Card
-            val electronicsCardSolid = gdml.solids.box(
-                cardShortSideX,
-                cardShortSideY,
-                cardLongSizeZ,
-                "electronicsCardSolid")
+            val SAFECSolid = gdml.solids.box(
+                SAFECShortSideX/2,
+                SAFECShortSideY,
+                SAFECLongSideZ,
+                "SAFECSolid")
 
             //Flat cable
-            val flatCableSolid = gdml.solids.box(
-                flatCableShortSideX,
-                flatCableShortSideY,
-                flatCableLongSideZ,
-                "flatCableSolid")
+            val SAFEC_MMSolid = gdml.solids.box(
+                SAFEC_MMShortSideX/2,
+                SAFEC_MMShortSideY,
+                SAFEC_MMLongSideZ,
+                "SAFEC_MMSolid")
 
             //chip
             val chipSolid = gdml.solids.box(
@@ -172,9 +185,9 @@ open class Electronics (
 
             //components
             val componentsSolid = gdml.solids.box(
-                componentsShortSideX,
-                componentsShortSideY,
-                componentsLongSideZ,
+                componentsSideX,
+                componentsSideY,
+                componentsSideZ,
                 "componentsSolid")
 
             val electronicsBoxVolume = 
@@ -183,11 +196,15 @@ open class Electronics (
             val electronicsBoxFillingVolume =
             gdml.structure.volume(Materials.Vacuum.ref,electronicsBoxInSolid,"electronicsBoxFillingVolume")
 
-            val electronicsCardVolume = 
-            gdml.structure.volume(Materials.Copper.ref,electronicsCardSolid,"electronicsCardVolume")
+            val kaptonSAFECVolume = 
+            gdml.structure.volume(Materials.Kapton.ref,SAFECSolid,"kaptonSAFECVolume")
+            val copperSAFECVolume = 
+            gdml.structure.volume(Materials.Copper.ref,SAFECSolid,"copperSAFECVolume")
 
-            val flatCableVolume =
-            gdml.structure.volume(Materials.Copper.ref,flatCableSolid,"flatCableVolume")
+            val copperSAFEC_MMVolume =
+            gdml.structure.volume(Materials.Copper.ref,SAFEC_MMSolid,"copperSAFEC_MMVolume")
+            val kaptonSAFEC_MMVolume =
+            gdml.structure.volume(Materials.Kapton.ref,SAFEC_MMSolid,"kaptonSAFEC_MMVolume")
 
             val chipVolume =
             gdml.structure.volume(Materials.Silicon.ref,chipSolid,"chipVolume")
@@ -200,57 +217,48 @@ open class Electronics (
                 //physVolume(electronicsBoxVolume, name = "electronicsBox")
                 //physVolume(electronicsBoxFillingVolume, name = "electronicsBoxFilling")
 
-                physVolume(electronicsCardVolume, name = "electronicsCard1"){
-                    position(x = - 15.0 ) { unit = LUnit.MM }
-                }
-                physVolume(electronicsCardVolume, name = "electronicsCard2"){
-                    position(x = - 5.0 ) { unit = LUnit.MM }
-                }
-                physVolume(electronicsCardVolume, name = "electronicsCard3"){
-                    position(x = 5.0 ) { unit = LUnit.MM }
-                }
-                physVolume(electronicsCardVolume, name = "electronicsCard4"){
-                    position(x = 15.0 ) { unit = LUnit.MM }
+                val positionsX = listOf(-15.0, -5.0, 5.0, 15.0)
+                //SAFEC: copperSAFEC{i} + kaptonSAFEC{i}
+                //SAFEC_MM: copperSAFEC_MM{i} + kaptonSAFEC_MM{i}
+                for (i in positionsX.indices) {
+                    val posX = positionsX[i]
+                    val copperName = "copperSAFEC${i + 1}"
+                    val kaptonName = "kaptonSAFEC${i + 1}"
+                    val coppersafecMMName = "copperSAFEC_MM${i + 1}"
+                    val kaptonsafecMMName = "kaptonSAFEC_MM${i + 1}"
+                    val chipName = "chip${i + 1}"
+                    val componentsName = "components${i + 1}"
+
+                    physVolume(copperSAFECVolume, name = copperName) {
+                        position(x = posX - SAFECShortSideX / 4) { unit = LUnit.MM }
+                    }
+
+                    physVolume(kaptonSAFECVolume, name = kaptonName) {
+                        position(x = posX + SAFECShortSideX / 4) { unit = LUnit.MM }
+                    }
+
+                    physVolume(copperSAFEC_MMVolume, name = coppersafecMMName) {
+                        position(
+                            x = posX + SAFECShortSideX / 2 + SAFEC_MMShortSideX / 4,
+                            z = -SAFECLongSideZ / 2 - SAFEC_MMLongSideZ / 2 + SAFECLimandeContactDistance
+                        ) { unit = LUnit.MM }
+                    }
+
+                    physVolume(kaptonSAFEC_MMVolume, name = kaptonsafecMMName) {
+                        position(
+                            x = posX + SAFECShortSideX / 2 + 3*SAFEC_MMShortSideX / 4,
+                            z = -SAFECLongSideZ / 2 - SAFEC_MMLongSideZ / 2 + SAFECLimandeContactDistance
+                        ) { unit = LUnit.MM }
+                    }
+
+                    physVolume(chipVolume, name = chipName){
+                    position(x = posX + SAFECShortSideX/2 + chipShortSideX/2, z = componentsSideY/2) { unit = LUnit.MM }
+                    }
+                    physVolume(componentsVolume, name = componentsName){
+                    position(x = posX + SAFECShortSideX/2 + componentsSideX/2, z = -componentsSideY/2) { unit = LUnit.MM }
+                    }
                 }
 
-                physVolume(chipVolume, name = "chip1"){
-                    position(x = - 15.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
-                }
-                physVolume(chipVolume, name = "chip2"){
-                    position(x = - 5.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
-                }
-                physVolume(chipVolume, name = "chip3"){
-                    position(x = 5.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
-                }
-                physVolume(chipVolume, name = "chip4"){
-                    position(x = 15.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
-                }
-
-                physVolume(componentsVolume, name = "components1"){
-                    position(x = - 15.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
-                }
-                physVolume(componentsVolume, name = "components2"){
-                    position(x = - 5.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
-                }
-                physVolume(componentsVolume, name = "components3"){
-                    position(x = 5.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
-                }
-                physVolume(componentsVolume, name = "components4"){
-                    position(x = 15.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
-                }
-
-                physVolume(flatCableVolume, name = "flatCable1"){
-                    position(x = - 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
-                physVolume(flatCableVolume, name = "flatCable2"){
-                    position(x = - 5.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
-                physVolume(flatCableVolume, name = "flatCable3"){
-                    position(x = 5.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
-                physVolume(flatCableVolume, name = "flatCable4"){
-                    position(x = 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
                 }
             }
         

--- a/generator/src/main/kotlin/BabyIAXO/Electronics.kt
+++ b/generator/src/main/kotlin/BabyIAXO/Electronics.kt
@@ -4,8 +4,9 @@ import Geometry
 
 import space.kscience.gdml.*
 
-open class Electronics : Geometry() {
-
+open class Electronics (    
+    open val detailedElectronics: Boolean = false,
+) : Geometry() {
     companion object Parameters {
 
         // Box : Dimensions 
@@ -24,6 +25,15 @@ open class Electronics : Geometry() {
         const val flatCableShortSideX: Double = 1.0
         const val flatCableShortSideY: Double = 70.0
 
+        //chip Dimensions
+        const val chipSideYZ: Double = 25.0
+        const val chipShortSideX: Double = 1.0
+
+        //components Dimensions
+        const val componentsLongSideZ: Double = 5.0
+        const val componentsShortSideX: Double = 1.0
+        const val componentsShortSideY: Double = 40.0
+
         // Distance 
         const val DetectorToElectronicsDistanceZ: Double = 235.0
         const val PipeToElectronicsOffSetX: Double = 5.0
@@ -32,7 +42,10 @@ open class Electronics : Geometry() {
     }
 
     override fun generate (gdml : Gdml): GdmlRef<GdmlAssembly> {
-        val electronicsBoxVolume: GdmlRef<GdmlAssembly> by lazy {
+
+        if(!detailedElectronics){
+
+            val electronicsBoxVolume: GdmlRef<GdmlAssembly> by lazy {
 
             //Box 
             val electronicsBoxOutSolid = gdml.solids.box(
@@ -109,9 +122,141 @@ open class Electronics : Geometry() {
                 physVolume(flatCableVolume, name = "flatCable4"){
                     position(x = 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
                 }
+                }
             }
-        }
         
-        return electronicsBoxVolume
+            return electronicsBoxVolume
+            
+        } else {
+            val electronicsBoxVolume: GdmlRef<GdmlAssembly> by lazy {
+
+            //Box 
+            val electronicsBoxOutSolid = gdml.solids.box(
+                electronicsBoxShortSideX,
+                electronicsBoxShortSideY,
+                electronicsBoxLongSideZ,
+                "electronicsBoxOutSolid"
+            )
+
+            val electronicsBoxInSolid = gdml.solids.box(
+                electronicsBoxShortSideX - electronicsBoxThickness*2,
+                electronicsBoxShortSideY - electronicsBoxThickness*2,
+                electronicsBoxLongSideZ - electronicsBoxThickness*2,
+                "electronicsBoxInSolid"
+            )
+
+            val electronicsBoxSolid = gdml.solids.subtraction(
+                electronicsBoxOutSolid, electronicsBoxInSolid,
+                "electronicsBoxSolid")
+
+            //Card
+            val electronicsCardSolid = gdml.solids.box(
+                cardShortSideX,
+                cardShortSideY,
+                cardLongSizeZ,
+                "electronicsCardSolid")
+
+            //Flat cable
+            val flatCableSolid = gdml.solids.box(
+                flatCableShortSideX,
+                flatCableShortSideY,
+                flatCableLongSideZ,
+                "flatCableSolid")
+
+            //chip
+            val chipSolid = gdml.solids.box(
+                chipShortSideX,
+                chipSideYZ,
+                chipSideYZ,
+                "chipSolid")
+
+            //components
+            val componentsSolid = gdml.solids.box(
+                componentsShortSideX,
+                componentsShortSideY,
+                componentsLongSideZ,
+                "componentsSolid")
+
+            val electronicsBoxVolume = 
+            gdml.structure.volume(Materials.Copper.ref,electronicsBoxSolid,"electronicsBoxVolume")
+
+            val electronicsBoxFillingVolume =
+            gdml.structure.volume(Materials.Vacuum.ref,electronicsBoxInSolid,"electronicsBoxFillingVolume")
+
+            val electronicsCardVolume = 
+            gdml.structure.volume(Materials.Copper.ref,electronicsCardSolid,"electronicsCardVolume")
+
+            val flatCableVolume =
+            gdml.structure.volume(Materials.Copper.ref,flatCableSolid,"flatCableVolume")
+
+            val chipVolume =
+            gdml.structure.volume(Materials.Silicon.ref,chipSolid,"chipVolume")
+
+            val componentsVolume =
+            gdml.structure.volume(Materials.Silicon.ref,componentsSolid,"componentsVolume")
+
+            return@lazy gdml.structure.assembly {
+                name = "electronicsBox"
+                //physVolume(electronicsBoxVolume, name = "electronicsBox")
+                //physVolume(electronicsBoxFillingVolume, name = "electronicsBoxFilling")
+
+                physVolume(electronicsCardVolume, name = "electronicsCard1"){
+                    position(x = - 15.0 ) { unit = LUnit.MM }
+                }
+                physVolume(electronicsCardVolume, name = "electronicsCard2"){
+                    position(x = - 5.0 ) { unit = LUnit.MM }
+                }
+                physVolume(electronicsCardVolume, name = "electronicsCard3"){
+                    position(x = 5.0 ) { unit = LUnit.MM }
+                }
+                physVolume(electronicsCardVolume, name = "electronicsCard4"){
+                    position(x = 15.0 ) { unit = LUnit.MM }
+                }
+
+                physVolume(chipVolume, name = "chip1"){
+                    position(x = - 15.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
+                }
+                physVolume(chipVolume, name = "chip2"){
+                    position(x = - 5.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
+                }
+                physVolume(chipVolume, name = "chip3"){
+                    position(x = 5.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
+                }
+                physVolume(chipVolume, name = "chip4"){
+                    position(x = 15.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
+                }
+
+                physVolume(componentsVolume, name = "components1"){
+                    position(x = - 15.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
+                }
+                physVolume(componentsVolume, name = "components2"){
+                    position(x = - 5.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
+                }
+                physVolume(componentsVolume, name = "components3"){
+                    position(x = 5.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
+                }
+                physVolume(componentsVolume, name = "components4"){
+                    position(x = 15.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
+                }
+
+                physVolume(flatCableVolume, name = "flatCable1"){
+                    position(x = - 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                physVolume(flatCableVolume, name = "flatCable2"){
+                    position(x = - 5.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                physVolume(flatCableVolume, name = "flatCable3"){
+                    position(x = 5.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                physVolume(flatCableVolume, name = "flatCable4"){
+                    position(x = 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                }
+            }
+        
+            return electronicsBoxVolume
+
+        }
+
     }
 }

--- a/generator/src/main/kotlin/BabyIAXO/Main.kt
+++ b/generator/src/main/kotlin/BabyIAXO/Main.kt
@@ -317,5 +317,37 @@ val geometries = mapOf(
             }
         }
     }.withUnits(LUnit.MM, AUnit.RAD),
+
+    "NoVetoesDetailedElectronics" to Gdml {
+
+        loadMaterialsFromUrl(materialsUrl) /* This adds all materials form the URL (we do not need them all) */
+
+        val chamberVolume = Chamber().generate(this)
+        val detectorPipeVolume = DetectorPipe().generate(this)
+        val electronicsBoxVolume = Electronics(detailedElectronics=true).generate(this)
+        val shieldingVolume = Shielding().generate(this)
+
+        structure {
+            val worldBox = solids.box(worldSizeX, worldSizeY, worldSizeZ, "worldBox")
+
+            world = volume(Materials.Air.ref, worldBox, "world") {
+                physVolume(chamberVolume, name = "Chamber")
+                physVolume(detectorPipeVolume, name = "DetectorPipe") {
+                    position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name = "ElectronicsBox") {
+                    position(
+                        x = Electronics.PipeToElectronicsDistanceX,
+                        z = Electronics.DetectorToElectronicsDistanceZ
+                    ) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(shieldingVolume, name = "Shielding")
+            }
+        }
+    }.withUnits(LUnit.MM, AUnit.RAD),
 )
 

--- a/generator/src/main/kotlin/IAXO-D1/Electronics.kt
+++ b/generator/src/main/kotlin/IAXO-D1/Electronics.kt
@@ -4,8 +4,9 @@ import Geometry
 
 import space.kscience.gdml.*
 
-open class Electronics : Geometry() {
-
+open class Electronics (    
+    open val detailedElectronics: Boolean = false,
+) : Geometry() {
     companion object Parameters {
 
         // Box : Dimensions 
@@ -24,6 +25,15 @@ open class Electronics : Geometry() {
         const val flatCableShortSideX: Double = 1.0
         const val flatCableShortSideY: Double = 70.0
 
+        //chip Dimensions
+        const val chipSideYZ: Double = 25.0
+        const val chipShortSideX: Double = 1.0
+
+        //components Dimensions
+        const val componentsLongSideZ: Double = 5.0
+        const val componentsShortSideX: Double = 1.0
+        const val componentsShortSideY: Double = 40.0
+
         // Distance 
         const val DetectorToElectronicsDistanceZ: Double = 235.0
         const val PipeToElectronicsOffSetX: Double = 5.0
@@ -32,8 +42,12 @@ open class Electronics : Geometry() {
     }
 
     override fun generate (gdml : Gdml): GdmlRef<GdmlAssembly> {
-        val electronicsBoxVolume: GdmlRef<GdmlAssembly> by lazy {
 
+        if(!detailedElectronics){
+
+            val electronicsBoxVolume: GdmlRef<GdmlAssembly> by lazy {
+
+            //Box 
             val electronicsBoxOutSolid = gdml.solids.box(
                 electronicsBoxShortSideX,
                 electronicsBoxShortSideY,
@@ -72,7 +86,7 @@ open class Electronics : Geometry() {
             val electronicsBoxFillingVolume =
             gdml.structure.volume(Materials.Vacuum.ref,electronicsBoxInSolid,"electronicsBoxFillingVolume")
 
-             val electronicsCardVolume = 
+            val electronicsCardVolume = 
             gdml.structure.volume(Materials.Copper.ref,electronicsCardSolid,"electronicsCardVolume")
 
             val flatCableVolume =
@@ -81,9 +95,7 @@ open class Electronics : Geometry() {
             return@lazy gdml.structure.assembly {
                 name = "electronicsBox"
                 //physVolume(electronicsBoxVolume, name = "electronicsBox")
-
                 //physVolume(electronicsBoxFillingVolume, name = "electronicsBoxFilling")
-
 
                 physVolume(electronicsCardVolume, name = "electronicsCard1"){
                     position(x = - 15.0 ) { unit = LUnit.MM }
@@ -110,9 +122,141 @@ open class Electronics : Geometry() {
                 physVolume(flatCableVolume, name = "flatCable4"){
                     position(x = 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
                 }
+                }
             }
-        }
         
-        return electronicsBoxVolume
+            return electronicsBoxVolume
+            
+        } else {
+            val electronicsBoxVolume: GdmlRef<GdmlAssembly> by lazy {
+
+            //Box 
+            val electronicsBoxOutSolid = gdml.solids.box(
+                electronicsBoxShortSideX,
+                electronicsBoxShortSideY,
+                electronicsBoxLongSideZ,
+                "electronicsBoxOutSolid"
+            )
+
+            val electronicsBoxInSolid = gdml.solids.box(
+                electronicsBoxShortSideX - electronicsBoxThickness*2,
+                electronicsBoxShortSideY - electronicsBoxThickness*2,
+                electronicsBoxLongSideZ - electronicsBoxThickness*2,
+                "electronicsBoxInSolid"
+            )
+
+            val electronicsBoxSolid = gdml.solids.subtraction(
+                electronicsBoxOutSolid, electronicsBoxInSolid,
+                "electronicsBoxSolid")
+
+            //Card
+            val electronicsCardSolid = gdml.solids.box(
+                cardShortSideX,
+                cardShortSideY,
+                cardLongSizeZ,
+                "electronicsCardSolid")
+
+            //Flat cable
+            val flatCableSolid = gdml.solids.box(
+                flatCableShortSideX,
+                flatCableShortSideY,
+                flatCableLongSideZ,
+                "flatCableSolid")
+
+            //chip
+            val chipSolid = gdml.solids.box(
+                chipShortSideX,
+                chipSideYZ,
+                chipSideYZ,
+                "chipSolid")
+
+            //components
+            val componentsSolid = gdml.solids.box(
+                componentsShortSideX,
+                componentsShortSideY,
+                componentsLongSideZ,
+                "componentsSolid")
+
+            val electronicsBoxVolume = 
+            gdml.structure.volume(Materials.Copper.ref,electronicsBoxSolid,"electronicsBoxVolume")
+
+            val electronicsBoxFillingVolume =
+            gdml.structure.volume(Materials.Vacuum.ref,electronicsBoxInSolid,"electronicsBoxFillingVolume")
+
+            val electronicsCardVolume = 
+            gdml.structure.volume(Materials.Copper.ref,electronicsCardSolid,"electronicsCardVolume")
+
+            val flatCableVolume =
+            gdml.structure.volume(Materials.Copper.ref,flatCableSolid,"flatCableVolume")
+
+            val chipVolume =
+            gdml.structure.volume(Materials.Silicon.ref,chipSolid,"chipVolume")
+
+            val componentsVolume =
+            gdml.structure.volume(Materials.Silicon.ref,componentsSolid,"componentsVolume")
+
+            return@lazy gdml.structure.assembly {
+                name = "electronicsBox"
+                //physVolume(electronicsBoxVolume, name = "electronicsBox")
+                //physVolume(electronicsBoxFillingVolume, name = "electronicsBoxFilling")
+
+                physVolume(electronicsCardVolume, name = "electronicsCard1"){
+                    position(x = - 15.0 ) { unit = LUnit.MM }
+                }
+                physVolume(electronicsCardVolume, name = "electronicsCard2"){
+                    position(x = - 5.0 ) { unit = LUnit.MM }
+                }
+                physVolume(electronicsCardVolume, name = "electronicsCard3"){
+                    position(x = 5.0 ) { unit = LUnit.MM }
+                }
+                physVolume(electronicsCardVolume, name = "electronicsCard4"){
+                    position(x = 15.0 ) { unit = LUnit.MM }
+                }
+
+                physVolume(chipVolume, name = "chip1"){
+                    position(x = - 15.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
+                }
+                physVolume(chipVolume, name = "chip2"){
+                    position(x = - 5.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
+                }
+                physVolume(chipVolume, name = "chip3"){
+                    position(x = 5.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
+                }
+                physVolume(chipVolume, name = "chip4"){
+                    position(x = 15.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
+                }
+
+                physVolume(componentsVolume, name = "components1"){
+                    position(x = - 15.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
+                }
+                physVolume(componentsVolume, name = "components2"){
+                    position(x = - 5.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
+                }
+                physVolume(componentsVolume, name = "components3"){
+                    position(x = 5.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
+                }
+                physVolume(componentsVolume, name = "components4"){
+                    position(x = 15.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
+                }
+
+                physVolume(flatCableVolume, name = "flatCable1"){
+                    position(x = - 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                physVolume(flatCableVolume, name = "flatCable2"){
+                    position(x = - 5.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                physVolume(flatCableVolume, name = "flatCable3"){
+                    position(x = 5.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                physVolume(flatCableVolume, name = "flatCable4"){
+                    position(x = 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
+                }
+                }
+            }
+        
+            return electronicsBoxVolume
+
+        }
+
     }
 }

--- a/generator/src/main/kotlin/IAXO-D1/Electronics.kt
+++ b/generator/src/main/kotlin/IAXO-D1/Electronics.kt
@@ -15,26 +15,27 @@ open class Electronics (
         const val electronicsBoxShortSideY: Double = 90.0
         const val electronicsBoxThickness: Double = 5.0
 
-        //Card Dimensions
-        const val cardLongSizeZ: Double = 100.0
-        const val cardShortSideX: Double = 2.5
-        const val cardShortSideY: Double = 70.0
+        //Card (SAFEC) Dimensions
+        const val SAFECLongSideZ: Double = 226.94
+        const val SAFECShortSideX: Double = 0.62
+        const val SAFECShortSideY: Double = 102.6
 
-        //flat cable Dimensions
-        const val flatCableLongSideZ: Double = 150.0
-        const val flatCableShortSideX: Double = 1.0
-        const val flatCableShortSideY: Double = 70.0
+        //flat cable (SAFEC_MM) Dimensions
+        const val SAFEC_MMLongSideZ: Double = 141.0 //had to reduce 20.0 mm to avoid overlap with pipe
+        const val SAFEC_MMShortSideX: Double = 0.2
+        const val SAFEC_MMShortSideY: Double = 102.25
 
         //chip Dimensions
-        const val chipSideYZ: Double = 25.0
+        const val chipSideYZ: Double = 28.0
         const val chipShortSideX: Double = 1.0
 
         //components Dimensions
-        const val componentsLongSideZ: Double = 5.0
-        const val componentsShortSideX: Double = 1.0
-        const val componentsShortSideY: Double = 40.0
+        const val componentsSideZ: Double = 9.3
+        const val componentsSideX: Double = 1.0
+        const val componentsSideY: Double = 76.2
 
         // Distance 
+        const val SAFECLimandeContactDistance: Double = 55.2
         const val DetectorToElectronicsDistanceZ: Double = 235.0
         const val PipeToElectronicsOffSetX: Double = 5.0
         const val PipeToElectronicsDistanceX: Double = 82.0 - (electronicsBoxShortSideX / 2) + PipeToElectronicsOffSetX
@@ -67,18 +68,18 @@ open class Electronics (
                 "electronicsBoxSolid")
 
             //Card
-            val electronicsCardSolid = gdml.solids.box(
-                cardShortSideX,
-                cardShortSideY,
-                cardLongSizeZ,
-                "electronicsCardSolid")
+            val SAFECSolid = gdml.solids.box(
+                SAFECShortSideX/2,
+                SAFECShortSideY,
+                SAFECLongSideZ,
+                "SAFECSolid")
 
             //Flat cable
-            val flatCableSolid = gdml.solids.box(
-                flatCableShortSideX,
-                flatCableShortSideY,
-                flatCableLongSideZ,
-                "flatCableSolid")
+            val SAFEC_MMSolid = gdml.solids.box(
+                SAFEC_MMShortSideX/2,
+                SAFEC_MMShortSideY,
+                SAFEC_MMLongSideZ,
+                "SAFEC_MMSolid")
 
             val electronicsBoxVolume = 
             gdml.structure.volume(Materials.Copper.ref,electronicsBoxSolid,"electronicsBoxVolume")
@@ -86,41 +87,53 @@ open class Electronics (
             val electronicsBoxFillingVolume =
             gdml.structure.volume(Materials.Vacuum.ref,electronicsBoxInSolid,"electronicsBoxFillingVolume")
 
-            val electronicsCardVolume = 
-            gdml.structure.volume(Materials.Copper.ref,electronicsCardSolid,"electronicsCardVolume")
+            val kaptonSAFECVolume = 
+            gdml.structure.volume(Materials.Kapton.ref,SAFECSolid,"kaptonSAFECVolume")
+            val copperSAFECVolume = 
+            gdml.structure.volume(Materials.Copper.ref,SAFECSolid,"copperSAFECVolume")
 
-            val flatCableVolume =
-            gdml.structure.volume(Materials.Copper.ref,flatCableSolid,"flatCableVolume")
+            val copperSAFEC_MMVolume =
+            gdml.structure.volume(Materials.Copper.ref,SAFEC_MMSolid,"copperSAFEC_MMVolume")
+            val kaptonSAFEC_MMVolume =
+            gdml.structure.volume(Materials.Kapton.ref,SAFEC_MMSolid,"kaptonSAFEC_MMVolume")
 
             return@lazy gdml.structure.assembly {
                 name = "electronicsBox"
                 //physVolume(electronicsBoxVolume, name = "electronicsBox")
                 //physVolume(electronicsBoxFillingVolume, name = "electronicsBoxFilling")
 
-                physVolume(electronicsCardVolume, name = "electronicsCard1"){
-                    position(x = - 15.0 ) { unit = LUnit.MM }
-                }
-                physVolume(electronicsCardVolume, name = "electronicsCard2"){
-                    position(x = - 5.0 ) { unit = LUnit.MM }
-                }
-                physVolume(electronicsCardVolume, name = "electronicsCard3"){
-                    position(x = 5.0 ) { unit = LUnit.MM }
-                }
-                physVolume(electronicsCardVolume, name = "electronicsCard4"){
-                    position(x = 15.0 ) { unit = LUnit.MM }
-                }
+                val positionsX = listOf(-15.0, -5.0, 5.0, 15.0)
 
-                physVolume(flatCableVolume, name = "flatCable1"){
-                    position(x = - 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
-                physVolume(flatCableVolume, name = "flatCable2"){
-                    position(x = - 5.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
-                physVolume(flatCableVolume, name = "flatCable3"){
-                    position(x = 5.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
-                physVolume(flatCableVolume, name = "flatCable4"){
-                    position(x = 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
+                //SAFEC: copperSAFEC{i} + kaptonSAFEC{i}
+                //SAFEC_MM: copperSAFEC_MM{i} + kaptonSAFEC_MM{i}
+                for (i in positionsX.indices) {
+                    val posX = positionsX[i]
+                    val copperName = "copperSAFEC${i + 1}"
+                    val kaptonName = "kaptonSAFEC${i + 1}"
+                    val coppersafecMMName = "copperSAFEC_MM${i + 1}"
+                    val kaptonsafecMMName = "kaptonSAFEC_MM${i + 1}"
+
+                    physVolume(copperSAFECVolume, name = copperName) {
+                        position(x = posX - SAFECShortSideX / 4) { unit = LUnit.MM }
+                    }
+
+                    physVolume(kaptonSAFECVolume, name = kaptonName) {
+                        position(x = posX + SAFECShortSideX / 4) { unit = LUnit.MM }
+                    }
+
+                    physVolume(copperSAFEC_MMVolume, name = coppersafecMMName) {
+                        position(
+                            x = posX + SAFECShortSideX / 2 + SAFEC_MMShortSideX / 4,
+                            z = -SAFECLongSideZ / 2 - SAFEC_MMLongSideZ / 2 + SAFECLimandeContactDistance
+                        ) { unit = LUnit.MM }
+                    }
+
+                    physVolume(kaptonSAFEC_MMVolume, name = kaptonsafecMMName) {
+                        position(
+                            x = posX + SAFECShortSideX / 2 + 3*SAFEC_MMShortSideX / 4,
+                            z = -SAFECLongSideZ / 2 - SAFEC_MMLongSideZ / 2 + SAFECLimandeContactDistance
+                        ) { unit = LUnit.MM }
+                    }
                 }
                 }
             }
@@ -150,18 +163,18 @@ open class Electronics (
                 "electronicsBoxSolid")
 
             //Card
-            val electronicsCardSolid = gdml.solids.box(
-                cardShortSideX,
-                cardShortSideY,
-                cardLongSizeZ,
-                "electronicsCardSolid")
+            val SAFECSolid = gdml.solids.box(
+                SAFECShortSideX/2,
+                SAFECShortSideY,
+                SAFECLongSideZ,
+                "SAFECSolid")
 
             //Flat cable
-            val flatCableSolid = gdml.solids.box(
-                flatCableShortSideX,
-                flatCableShortSideY,
-                flatCableLongSideZ,
-                "flatCableSolid")
+            val SAFEC_MMSolid = gdml.solids.box(
+                SAFEC_MMShortSideX/2,
+                SAFEC_MMShortSideY,
+                SAFEC_MMLongSideZ,
+                "SAFEC_MMSolid")
 
             //chip
             val chipSolid = gdml.solids.box(
@@ -172,9 +185,9 @@ open class Electronics (
 
             //components
             val componentsSolid = gdml.solids.box(
-                componentsShortSideX,
-                componentsShortSideY,
-                componentsLongSideZ,
+                componentsSideX,
+                componentsSideY,
+                componentsSideZ,
                 "componentsSolid")
 
             val electronicsBoxVolume = 
@@ -183,11 +196,15 @@ open class Electronics (
             val electronicsBoxFillingVolume =
             gdml.structure.volume(Materials.Vacuum.ref,electronicsBoxInSolid,"electronicsBoxFillingVolume")
 
-            val electronicsCardVolume = 
-            gdml.structure.volume(Materials.Copper.ref,electronicsCardSolid,"electronicsCardVolume")
+            val kaptonSAFECVolume = 
+            gdml.structure.volume(Materials.Kapton.ref,SAFECSolid,"kaptonSAFECVolume")
+            val copperSAFECVolume = 
+            gdml.structure.volume(Materials.Copper.ref,SAFECSolid,"copperSAFECVolume")
 
-            val flatCableVolume =
-            gdml.structure.volume(Materials.Copper.ref,flatCableSolid,"flatCableVolume")
+            val copperSAFEC_MMVolume =
+            gdml.structure.volume(Materials.Copper.ref,SAFEC_MMSolid,"copperSAFEC_MMVolume")
+            val kaptonSAFEC_MMVolume =
+            gdml.structure.volume(Materials.Kapton.ref,SAFEC_MMSolid,"kaptonSAFEC_MMVolume")
 
             val chipVolume =
             gdml.structure.volume(Materials.Silicon.ref,chipSolid,"chipVolume")
@@ -200,57 +217,48 @@ open class Electronics (
                 //physVolume(electronicsBoxVolume, name = "electronicsBox")
                 //physVolume(electronicsBoxFillingVolume, name = "electronicsBoxFilling")
 
-                physVolume(electronicsCardVolume, name = "electronicsCard1"){
-                    position(x = - 15.0 ) { unit = LUnit.MM }
-                }
-                physVolume(electronicsCardVolume, name = "electronicsCard2"){
-                    position(x = - 5.0 ) { unit = LUnit.MM }
-                }
-                physVolume(electronicsCardVolume, name = "electronicsCard3"){
-                    position(x = 5.0 ) { unit = LUnit.MM }
-                }
-                physVolume(electronicsCardVolume, name = "electronicsCard4"){
-                    position(x = 15.0 ) { unit = LUnit.MM }
+                val positionsX = listOf(-15.0, -5.0, 5.0, 15.0)
+                //SAFEC: copperSAFEC{i} + kaptonSAFEC{i}
+                //SAFEC_MM: copperSAFEC_MM{i} + kaptonSAFEC_MM{i}
+                for (i in positionsX.indices) {
+                    val posX = positionsX[i]
+                    val copperName = "copperSAFEC${i + 1}"
+                    val kaptonName = "kaptonSAFEC${i + 1}"
+                    val coppersafecMMName = "copperSAFEC_MM${i + 1}"
+                    val kaptonsafecMMName = "kaptonSAFEC_MM${i + 1}"
+                    val chipName = "chip${i + 1}"
+                    val componentsName = "components${i + 1}"
+
+                    physVolume(copperSAFECVolume, name = copperName) {
+                        position(x = posX - SAFECShortSideX / 4) { unit = LUnit.MM }
+                    }
+
+                    physVolume(kaptonSAFECVolume, name = kaptonName) {
+                        position(x = posX + SAFECShortSideX / 4) { unit = LUnit.MM }
+                    }
+
+                    physVolume(copperSAFEC_MMVolume, name = coppersafecMMName) {
+                        position(
+                            x = posX + SAFECShortSideX / 2 + SAFEC_MMShortSideX / 4,
+                            z = -SAFECLongSideZ / 2 - SAFEC_MMLongSideZ / 2 + SAFECLimandeContactDistance
+                        ) { unit = LUnit.MM }
+                    }
+
+                    physVolume(kaptonSAFEC_MMVolume, name = kaptonsafecMMName) {
+                        position(
+                            x = posX + SAFECShortSideX / 2 + 3*SAFEC_MMShortSideX / 4,
+                            z = -SAFECLongSideZ / 2 - SAFEC_MMLongSideZ / 2 + SAFECLimandeContactDistance
+                        ) { unit = LUnit.MM }
+                    }
+
+                    physVolume(chipVolume, name = chipName){
+                    position(x = posX + SAFECShortSideX/2 + chipShortSideX/2, z = componentsSideY/2) { unit = LUnit.MM }
+                    }
+                    physVolume(componentsVolume, name = componentsName){
+                    position(x = posX + SAFECShortSideX/2 + componentsSideX/2, z = -componentsSideY/2) { unit = LUnit.MM }
+                    }
                 }
 
-                physVolume(chipVolume, name = "chip1"){
-                    position(x = - 15.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
-                }
-                physVolume(chipVolume, name = "chip2"){
-                    position(x = - 5.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
-                }
-                physVolume(chipVolume, name = "chip3"){
-                    position(x = 5.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
-                }
-                physVolume(chipVolume, name = "chip4"){
-                    position(x = 15.0 + cardShortSideX/2 + chipShortSideX/2) { unit = LUnit.MM }
-                }
-
-                physVolume(componentsVolume, name = "components1"){
-                    position(x = - 15.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
-                }
-                physVolume(componentsVolume, name = "components2"){
-                    position(x = - 5.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
-                }
-                physVolume(componentsVolume, name = "components3"){
-                    position(x = 5.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
-                }
-                physVolume(componentsVolume, name = "components4"){
-                    position(x = 15.0 + cardShortSideX/2 + componentsShortSideX/2, z = -30.0 ) { unit = LUnit.MM }
-                }
-
-                physVolume(flatCableVolume, name = "flatCable1"){
-                    position(x = - 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
-                physVolume(flatCableVolume, name = "flatCable2"){
-                    position(x = - 5.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
-                physVolume(flatCableVolume, name = "flatCable3"){
-                    position(x = 5.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
-                physVolume(flatCableVolume, name = "flatCable4"){
-                    position(x = 15.0, z = - cardLongSizeZ / 2 - flatCableLongSideZ / 2) { unit = LUnit.MM }
-                }
                 }
             }
         

--- a/generator/src/main/kotlin/IAXO-D1/Main.kt
+++ b/generator/src/main/kotlin/IAXO-D1/Main.kt
@@ -336,5 +336,36 @@ val geometries = mapOf(
             }
         }
     }.withUnits(LUnit.MM, AUnit.RAD),
+    "NoVetoesDetailedElectronics" to Gdml {
+
+        loadMaterialsFromUrl(materialsUrl) /* This adds all materials form the URL (we do not need them all) */
+
+        val chamberVolume = Chamber().generate(this)
+        val detectorPipeVolume = DetectorPipe().generate(this)
+        val electronicsBoxVolume = Electronics(detailedElectronics=true).generate(this)
+        val shieldingVolume = Shielding().generate(this)
+
+        structure {
+            val worldBox = solids.box(worldSizeX, worldSizeY, worldSizeZ, "worldBox")
+
+            world = volume(Materials.Air.ref, worldBox, "world") {
+                physVolume(chamberVolume, name = "Chamber")
+                physVolume(detectorPipeVolume, name = "DetectorPipe") {
+                    position(z = DetectorPipe.ZinWorld) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(electronicsBoxVolume, name = "ElectronicsBox") {
+                    position(
+                        x = Electronics.PipeToElectronicsDistanceX,
+                        z = Electronics.DetectorToElectronicsDistanceZ
+                    ) {
+                        unit = LUnit.MM
+                    }
+                }
+                physVolume(shieldingVolume, name = "Shielding")
+            }
+        }
+    }.withUnits(LUnit.MM, AUnit.RAD),
 )
 

--- a/generator/src/main/kotlin/Materials.kt
+++ b/generator/src/main/kotlin/Materials.kt
@@ -36,5 +36,6 @@ enum class Materials(val ref: GdmlRef<GdmlMaterial>) {
     BoratedHDPE5pct(resolve("BoratedHDPE5pct")),
     EJ254_5pct(resolve("EJ254-5pct")),
     EJ254_1pct(resolve("EJ254-1pct")),
+    Silicon(resolve("G4_Si"))
 }
 


### PR DESCRIPTION
New geometry to have a more detailed description of the elements inside the FEC of the radiopure electronics. We will launch a  simulation to see if there's a difference between simulating the events uniformly in the FEC/limande and this situation.

![imagen](https://github.com/user-attachments/assets/b977ba35-23c0-4ed8-a444-1028bd1364aa)

Here you can see the dimensions and the elements that I have included:
![imagen](https://github.com/user-attachments/assets/ae7e403e-c238-4b09-babf-4c980d70249f)

For the FEC I chose a **2.5 mm thickness copper foil**, for the flat cables **1.0 mm and copper** and for the chip and the components, **1.0 mm and silicon** as material.

Some questions:
- [x] Are there any dimensions that should be corrected because they are very different? (In particular the thickness)
- [x] Should I model the material for the FEC and limandes as kapton+copper (one foil of kapton and other of copper)?